### PR TITLE
Add pass-through for mozBackgroundRequest on GM_XHR per 1176

### DIFF
--- a/content/xmlhttprequester.js
+++ b/content/xmlhttprequester.js
@@ -61,6 +61,10 @@ function(safeUrl, details, req) {
   this.setupRequestEvent(this.unsafeContentWin, req, "onreadystatechange",
                          details);
 
+  if (details.mozBackgroundRequest) {
+      req.mozBackgroundRequest = true;
+  }
+
   req.open(details.method, safeUrl, true, details.user || "", details.password || "");
 
   if (details.overrideMimeType) {


### PR DESCRIPTION
Tested that this works and solves my immediate problem. I set to true rather than copying value on the assumption this reduces any possible security issues, e.g. due to bugs in the underlying implementation.
