### PR TITLE
Change build.sh to take "packed install" (Firefox 4) into account

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -46,7 +46,7 @@ sed \
 cat tmp > chrome.manifest
 rm tmp
 find content skin locale | sort | \
-  zip -r1@ "greasemonkey.jar" > /dev/null
+  zip -r1@D "greasemonkey.jar" > /dev/null
 rm -fr content/ skin/ locale/
 mkdir chrome
 mv greasemonkey.jar chrome/
@@ -56,8 +56,8 @@ find . -depth -name '*~' -exec rm -rf "{}" \;
 find . -depth -name '#*' -exec rm -rf "{}" \;
 
 echo "Creating $GMXPI ..."
-zip -qr1X "../$GMXPI" * -x \*.jar
-zip -qm0X "../$GMXPI" chrome/greasemonkey.jar
+zip -qr1XD "../$GMXPI" * -x \*.jar
+zip -qm0XD "../$GMXPI" chrome/greasemonkey.jar
 
 echo "Cleaning up temporary files ..."
 cd ..


### PR DESCRIPTION
See [this blog post](http://blog.mozilla.com/mwu/2010/09/10/extensions-now-installed-packed/) for further information.

As for the compression setting change, -0 would mean the best runtime performance, but the xpi is about 2x as large. The diff is size between compression setting -1 (fastest + worst compression) vs -9 (slowest + best compression) is about 9kb, so I figured -1 would be better since it'll mean that decompression will have as little impact as possible.
