### PR TITLE
lazy load nsIAppShellService for startup performance

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -9,8 +9,9 @@ const Cu = Components.utils;
 
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
 
-const appSvc = Cc["@mozilla.org/appshell/appShellService;1"]
-                 .getService(Ci.nsIAppShellService);
+XPCOMUtils.defineLazyServiceGetter(
+    this, "appSvc", "@mozilla.org/appshell/appShellService;1",
+    "nsIAppShellService");
 
 const gmSvcFilename = Components.stack.filename;
 


### PR DESCRIPTION
By not loading nsIAppShellService until it is first used it will not be loaded during startup, it'll load the first time a userscript is applied to a page, so if gm is disabled or has only a few userscripts installed, then it will either never load or load at a later point in their session (when it's actually needed). 
