### PR TITLE
remove install menuitem from Tools > Greasemonkey

### DIFF
--- a/content/browser.js
+++ b/content/browser.js
@@ -345,7 +345,7 @@ GM_BrowserUI.toolsMenuShowing = function() {
   var hidden = true;
 
   if (window._content && window._content.location &&
-      window.content.location.href.match(/\.user\.js(\?|$)/i)) {
+      window.content.location.href.match(/\.user(?:-\d+)\.js(\?|$)/i)) {
     hidden = false;
   }
 


### PR DESCRIPTION
This is similar to [this commit](http://github.com/greasemonkey/greasemonkey/commit/ff9eb88cb7f86b87a753a76e12ed4ea2a84e7215) but instead of being for the install banner, it's for the menuitem in the tools menu.

Another option is to [remove this menuitem](http://github.com/erikvold/greasemonkey/commit/eae1661d6bddd16b8966e835974c2516f85358ec), just putting it out there..
