### PR TITLE
Solve #1264, Growl is installed but not running does not allow user to install scripts

### DIFF
--- a/modules/GM_notification.js
+++ b/modules/GM_notification.js
@@ -2,15 +2,22 @@ var EXPORTED_SYMBOLS = ["GM_notification"];
 
 const {classes: Cc, interfaces: Ci} = Components;
 
-try {
-  var notify = Cc["@mozilla.org/alerts-service;1"]
-      .getService(Ci.nsIAlertsService)
-      .showAlertNotification;
-} catch (e) {
-  var notify = function() {
-    Cc["@mozilla.org/embedcomp/prompt-service;1"]
-        .getService(Ci.nsIPromptService)
-        .alert(null, "Greasemonkey alert", arguments[2]);
+// The first time this runs, we check if nsIAlertsService is installed and
+// works. If it fails, we re-define notify to use nsIPromptService always.
+// We check to see if nsIAlertsService works because of the case where Growl
+// is installed. See also https://bugzilla.mozilla.org/show_bug.cgi?id=597165
+function notify() {
+  try {
+    Cc["@mozilla.org/alerts-service;1"]
+        .getService(Ci.nsIAlertsService)
+        .showAlertNotification.apply(null, arguments);
+  } catch (e) {
+    notify = function() {
+      Cc["@mozilla.org/embedcomp/prompt-service;1"]
+          .getService(Ci.nsIPromptService)
+          .alert(null, "Greasemonkey alert", arguments[2]);
+    };
+    notify.apply(null, arguments);
   }
 }
 


### PR DESCRIPTION
STR for problem: (only known on Mac OS X)
1. Install Growl but stop the service in System Preferences.
2. Try to install a script from userscripts.org

At this point the install dialog shows up but clicking on the Install button does nothing. This is because the notify call fails and is documented in https://bugzilla.mozilla.org/show_bug.cgi?id=597165

The fix here tries to send an alert through the Growl service, and if it fails resort to the default method. Like the previous method, it redefines the behaviour of |notify| to always use the default method if the Growl service fails.
