### PR TITLE
Fixes #1220

### DIFF
--- a/content/addons4-overlay.js
+++ b/content/addons4-overlay.js
@@ -106,11 +106,15 @@ function onContextPopupShowing(aEvent) {
     var menuitemIsUserScript = ('user-script' == menuitem.getAttribute('type'));
     menuitem.collapsed = selectedIsUserScript != menuitemIsUserScript;
   }
-  
-  document.getElementById('menuitem_userscript_execute_first').style.display  = (0 === (selectedItem.getAttribute('executionIndex') * 1)) ? "none" : "";
-  document.getElementById('menuitem_userscript_execute_sooner').style.display = (0 === (selectedItem.getAttribute('executionIndex') * 1)) ? "none" : "";
-  document.getElementById('menuitem_userscript_execute_later').style.display  = ((document.getElementById('addon-list').children.length - 1) === (selectedItem.getAttribute('executionIndex') * 1)) ? "none" : "";
-  document.getElementById('menuitem_userscript_execute_last').style.display   = ((document.getElementById('addon-list').children.length - 1) === (selectedItem.getAttribute('executionIndex') * 1)) ? "none" : "";
+
+
+  document.getElementById('menuitem_userscript_context_execution_position').label = "Position: " +
+      ((selectedItem.getAttribute('executionIndex') * 1) + 1) + " / " + (document.getElementById('addon-list').children.length);
+  document.getElementById('menuitem_userscript_context_execution_position').collapsed = "";
+  document.getElementById('menuitem_userscript_execute_first').collapsed  = (0 === (selectedItem.getAttribute('executionIndex') * 1));
+  document.getElementById('menuitem_userscript_execute_sooner').collapsed = (0 === (selectedItem.getAttribute('executionIndex') * 1));
+  document.getElementById('menuitem_userscript_execute_later').collapsed  = ((document.getElementById('addon-list').children.length - 1) === (selectedItem.getAttribute('executionIndex') * 1));
+  document.getElementById('menuitem_userscript_execute_last').collapsed   = ((document.getElementById('addon-list').children.length - 1) === (selectedItem.getAttribute('executionIndex') * 1));
 };
 
 function onSortersClicked(aEvent) {

--- a/content/addons4-overlay.xul
+++ b/content/addons4-overlay.xul
@@ -42,6 +42,9 @@
     label="&Show;" accesskey="&Show.accesskey;" type="user-script"
   />
   <menuseparator type="user-script"/>
+  <menuitem id="menuitem_userscript_context_execution_position"
+    label="Position: "
+  />
   <menuitem id="menuitem_userscript_execute_first"
     command="cmd_userscript_execute_first"
     label="&ExecuteFirst;" type="user-script"

--- a/skin/addons4.css
+++ b/skin/addons4.css
@@ -25,3 +25,7 @@ page.greasemonkey #addon-list-empty,
 page.greasemonkey #user-script-list-empty {
   display: -moz-box;
 }
+#menuitem_userscript_context_execution_position {
+  opacity: 0.6;
+  font-style: italic;
+}


### PR DESCRIPTION
Note that setting the `.disabled` values to true did not appear to remove/hide/disable the menu items despite DOM Inspector and Firebug both indicating that the attribute was being set to true successfully. This is the reason that CSS has been used.
