### PR TITLE
Conflict .className and .classList

### DIFF
--- a/content/addons4-overlay.js
+++ b/content/addons4-overlay.js
@@ -208,7 +208,7 @@ function onViewChanged(aEvent) {
     applySort();
   } else {
     document.documentElement.className = document.documentElement.className
-        .replace(/ greasemonkey/g, '');
+        .replace(/^greasemonkey| greasemonkey/g, '');
   }
 };
 


### PR DESCRIPTION
If someone uses "classList.remove" method (see https://developer.mozilla.org/en-US/docs/DOM/element.classList) to remove a class from the Addon Manager's <page> element, the Greasemonkey will not be able delete "greasemonkey" class, because "classList.remove" method deletes leading spaces from "className" property
