### PR TITLE
Issue #1670 fix

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -292,7 +292,9 @@ function runScriptInSandbox(script, sandbox) {
         // not in a function.
         GM_util.logError(
             gStringBundle.GetStringFromName('return-not-in-func-deprecated'),
-            true // is a warning
+            true, // is a warning
+            fileName,
+            e.lineNumber
             );
         Components.utils.evalInSandbox(
             GM_util.anonWrap(code), sandbox, gMaxJSVersion, fileName, 1);


### PR DESCRIPTION
The minor modifications needed for Issue #1670 to show file name and line number where a return statement is used incorrectly.

For some reason this pull request shows 4 commits although there should be just one, and only one file is affected, namely components/greasemonkey.js
