### PR TITLE
Fix undefined variable access.

### DIFF
--- a/content/newscript.js
+++ b/content/newscript.js
@@ -28,7 +28,7 @@ window.addEventListener("load", function window_load() {
 
   gClipText = getClipText()
   document.documentElement.getButton('extra2').collapsed =
-      !(clipText && extractMeta(clipText));
+      !(gClipText && extractMeta(gClipText));
 }, false);
 
 function doInstall() {


### PR DESCRIPTION
This would throw and thus leave the "Use Script from Clipboard" button visible, even if the clipboard did not contain a valid userscript.
