### PR TITLE
Fix typo causing unnecessary array duplication

### DIFF
--- a/modules/script.js
+++ b/modules/script.js
@@ -91,7 +91,7 @@ Script.prototype.matchesURL = function(url) {
   if (this._userIncludes.some(testClude)) return true;
 
   // Finally allow based on script cludes and matches.
-  if (this.excludes.some(testClude)) return false;
+  if (this._excludes.some(testClude)) return false;
   return (this._includes.some(testClude) || this._matches.some(testMatch));
 };
 


### PR DESCRIPTION
While validating #1689, it occurred to me that at some point `this.excludes` where the other surrounding lines were using something like `this._includes`. This turns out to be a typo that unnecessary causes an `this._excludes.concat()`.

The attached patch fixes this minor bug, it will probably not be noticable, but it won't harm either.
