### PR TITLE
A @nosandbox Option . . . 

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -108,7 +108,8 @@ function createSandbox(
     aScript, aContentWin, aChromeWin, aFirebugConsole, aUrl
 ) {
   var sandbox = null;
-  if (GM_util.inArray(aScript.grants, 'none') || aScript.nosandbox) {
+  if (GM_util.inArray(aScript.grants, 'none')
+      || (aScript.nosandbox && aScript.userNosandbox)) {
     // If there is an explicit none grant or nosandbox is set,
     // use a plain unwrapped sandbox with no other content.
     sandbox = new Components.utils.Sandbox(

--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -196,7 +196,7 @@ function createSandbox(
   }
   if (GM_util.inArray(aScript.grants, 'GM_xmlhttpRequest')) {
     sandbox.GM_xmlhttpRequest = GM_util.hitch(
-        new GM_xmlhttpRequester(aContentWin, aChromeWin, aUrl),
+        new GM_xmlhttpRequester(aContentWin, aChromeWin, aUrl, aScript),
         'contentStartRequest');
   }
 

--- a/content/advancedscriptprefs.js
+++ b/content/advancedscriptprefs.js
@@ -1,0 +1,60 @@
+Components.utils.import('resource://greasemonkey/util.js'); // ref'd in XUL
+
+var gScriptId = location.hash.substring(1);
+var gScript = GM_util.getService().config.getMatchingScripts(function(script) {
+  return script.id == gScriptId;
+})[0];
+
+var gUserTabEl;
+var gUserNoSandboxEl;
+var gScriptNoSandboxEl;
+var gCorsScriptIncludesEl;
+var gCorsScriptExcludesEl;
+var gCorsUserIncludesEl;
+var gCorsUserExcludesEl;
+
+function onAdvancedDialogLoad() {
+  // I wanted "%s" but % is reserved in a DTD and I don't know the literal.
+  document.title = document.title.replace('!!', gScript.name);
+
+  var gTabboxEl = document.getElementsByTagName('tabbox')[0];
+  gUserTabEl = gTabboxEl.tabs.getItemAtIndex(0);
+
+  gCorsUserIncludesEl = document.getElementById('cors-user-includes');
+  gCorsUserExcludesEl = document.getElementById('cors-user-excludes');
+  gUserNoSandboxEl = document.getElementById('user-nosandbox');
+
+  gCorsScriptIncludesEl = document.getElementById('cors-script-includes');
+  gCorsScriptExcludesEl = document.getElementById('cors-script-excludes');
+  gScriptNoSandboxEl = document.getElementById('script-nosandbox');
+
+  gCorsScriptIncludesEl.pages = gScript.corsIncludes;
+  gCorsScriptIncludesEl.onAddUserExclude = function(url) {
+    gCorsUserExcludesEl.addPage(url);
+    gTabboxEl.selectedTab = gUserTabEl;
+  };
+  gCorsUserIncludesEl.pages = gScript.corsUserIncludes;
+
+  gUserNoSandboxEl.checked = gScript.userNosandbox;
+  gScriptNoSandboxEl.checked = gScript.nosandbox;
+
+  gCorsScriptExcludesEl.pages = gScript.corsExcludes;
+  gCorsScriptExcludesEl.onAddUserInclude = function(url) {
+    gCorsUserIncludesEl.addPage(url);
+    gTabboxEl.selectedTab = gUserTabEl;
+  };
+
+  gCorsUserExcludesEl.pages = gScript.corsUserExcludes;
+}
+
+function onAdvancedDialogAccept() {
+  gScript.corsExcludes = gCorsScriptExcludesEl.pages;
+  gScript.corsIncludes = gCorsScriptIncludesEl.pages;
+  gScript.corsUserExcludes = gCorsUserExcludesEl.pages;
+  gScript.corsUserIncludes = gCorsUserIncludesEl.pages;
+  gScript.userNosandbox = gUserNoSandboxEl.checked;
+  gScript.nosandbox = gScriptNoSandboxEl.checked;
+  GM_util.getService().config._changed(gScript, "cludes");
+  return true;
+}
+

--- a/content/advancedscriptprefs.xul
+++ b/content/advancedscriptprefs.xul
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+
+<?xml-stylesheet href="chrome://global/skin/" type="text/css"?>
+<?xml-stylesheet href="chrome://greasemonkey/skin/bindings.css" type="text/css"?>
+<?xml-stylesheet href="chrome://greasemonkey/skin/scriptprefs.css" type="text/css"?>
+
+<!DOCTYPE prefwindow [
+<!ENTITY % addonsDTD SYSTEM "chrome://greasemonkey/locale/gm-addons.dtd">
+<!ENTITY % cludesDTD SYSTEM "chrome://greasemonkey/locale/gm-cludes.dtd">
+<!ENTITY % greasemonkeyDTD SYSTEM "chrome://greasemonkey/locale/greasemonkey.dtd">
+%addonsDTD;
+%cludesDTD;
+%greasemonkeyDTD;
+]>
+
+<dialog xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
+  buttons="accept,cancel"
+  title="&advancedscriptprefs.title;"
+  onload="return onAdvancedDialogLoad();"
+  ondialogaccept="return onAdvancedDialogAccept();"
+>
+<script type="application/x-javascript" src="chrome://greasemonkey/content/advancedscriptprefs.js" />
+
+<tabbox>
+  <tabs>
+    <tab label="&advancedscriptprefs.usersettings;" />
+    <tab label="&advancedscriptprefs.scriptsettings;" />
+  </tabs>
+  <tabpanels>
+    <tabpanel>
+      <vbox flex="1">
+        <label value="&label.corsIncluded;" />
+        <cludes id="cors-user-includes"/>
+        <label value="&label.corsExcluded;" />
+        <cludes id="cors-user-excludes" />
+        <groupbox>
+          <caption label="&UnsafeScripting;" />
+          <checkbox id="user-nosandbox" label="&NoSandboxMode;" />
+        </groupbox>
+      </vbox>
+    </tabpanel>
+    <tabpanel>
+      <vbox flex="1">
+        <vbox flex="1" class="in">
+          <label value="&label.corsIncluded;" />
+          <cludes id="cors-script-includes" class="readonly" />
+        </vbox>
+        <vbox flex="1" class="ex">
+          <label value="&label.corsExcluded;" />
+          <cludes id="cors-script-excludes" class="readonly" />
+        </vbox>
+        <groupbox>
+          <caption label="&UnsafeScripting;" />
+          <checkbox id="script-nosandbox" label="&NoSandboxMode;" />
+        </groupbox>
+      </vbox>
+    </tabpanel>
+  </tabpanels>
+</tabbox>
+
+</dialog>

--- a/content/scriptprefs.js
+++ b/content/scriptprefs.js
@@ -10,6 +10,8 @@ var gScriptIncludesEl;
 var gTabboxEl;
 var gUserExcludesEl;
 var gUserIncludesEl;
+var gUserNoSandboxEl;
+var gScriptNoSandboxEl;
 var gUserTabEl;
 
 window.addEventListener('load', function() {
@@ -21,8 +23,10 @@ window.addEventListener('load', function() {
 
   gUserIncludesEl = document.getElementById('user-includes');
   gUserExcludesEl = document.getElementById('user-excludes');
+  gUserNoSandboxEl = document.getElementById('user-nosandbox');
   gScriptIncludesEl = document.getElementById('script-includes');
   gScriptExcludesEl = document.getElementById('script-excludes');
+  gScriptNoSandboxEl = document.getElementById('script-nosandbox');
 
   gScriptIncludesEl.pages = gScript.includes;
   gScriptIncludesEl.onAddUserExclude = function(url) {
@@ -30,6 +34,9 @@ window.addEventListener('load', function() {
     gTabboxEl.selectedTab = gUserTabEl;
   };
   gUserIncludesEl.pages = gScript.userIncludes;
+
+  gUserNoSandboxEl.checked = gScript.userNosandbox;
+  gScriptNoSandboxEl.checked = gScript.nosandbox;
 
   gScriptExcludesEl.pages = gScript.excludes;
   gScriptExcludesEl.onAddUserInclude = function(url) {
@@ -44,5 +51,7 @@ function onDialogAccept() {
   gScript.userIncludes = gUserIncludesEl.pages;
   gScript.excludes = gScriptExcludesEl.pages;
   gScript.userExcludes = gUserExcludesEl.pages;
+  gScript.userNosandbox = gUserNoSandboxEl.checked;
+  gScript.nosandbox = gScriptNoSandboxEl.checked;
   GM_util.getService().config._changed(gScript, "cludes");
 }

--- a/content/scriptprefs.js
+++ b/content/scriptprefs.js
@@ -10,8 +10,6 @@ var gScriptIncludesEl;
 var gTabboxEl;
 var gUserExcludesEl;
 var gUserIncludesEl;
-var gUserNoSandboxEl;
-var gScriptNoSandboxEl;
 var gUserTabEl;
 
 window.addEventListener('load', function() {
@@ -23,10 +21,8 @@ window.addEventListener('load', function() {
 
   gUserIncludesEl = document.getElementById('user-includes');
   gUserExcludesEl = document.getElementById('user-excludes');
-  gUserNoSandboxEl = document.getElementById('user-nosandbox');
   gScriptIncludesEl = document.getElementById('script-includes');
   gScriptExcludesEl = document.getElementById('script-excludes');
-  gScriptNoSandboxEl = document.getElementById('script-nosandbox');
 
   gScriptIncludesEl.pages = gScript.includes;
   gScriptIncludesEl.onAddUserExclude = function(url) {
@@ -34,9 +30,6 @@ window.addEventListener('load', function() {
     gTabboxEl.selectedTab = gUserTabEl;
   };
   gUserIncludesEl.pages = gScript.userIncludes;
-
-  gUserNoSandboxEl.checked = gScript.userNosandbox;
-  gScriptNoSandboxEl.checked = gScript.nosandbox;
 
   gScriptExcludesEl.pages = gScript.excludes;
   gScriptExcludesEl.onAddUserInclude = function(url) {
@@ -51,7 +44,9 @@ function onDialogAccept() {
   gScript.userIncludes = gUserIncludesEl.pages;
   gScript.excludes = gScriptExcludesEl.pages;
   gScript.userExcludes = gUserExcludesEl.pages;
-  gScript.userNosandbox = gUserNoSandboxEl.checked;
-  gScript.nosandbox = gScriptNoSandboxEl.checked;
   GM_util.getService().config._changed(gScript, "cludes");
+}
+
+function onDisplayAdvancedDialog() {
+  openDialog('chrome://greasemonkey/content/advancedscriptprefs.xul#' + gScript.id, null, 'modal');
 }

--- a/content/scriptprefs.xul
+++ b/content/scriptprefs.xul
@@ -33,6 +33,10 @@
         <cludes id="user-includes"/>
         <label value="&label.grpExcluded;" />
         <cludes id="user-excludes" />
+        <groupbox>
+          <caption label="&UnsafeScripting;" />
+          <checkbox id="user-nosandbox" label="&NoSandboxMode;" />
+        </groupbox>
       </vbox>
     </tabpanel>
     <tabpanel>
@@ -45,6 +49,10 @@
           <label value="&label.grpExcluded;" />
           <cludes id="script-excludes" class="readonly" />
         </vbox>
+        <groupbox>
+          <caption label="&UnsafeScripting;" />
+          <checkbox id="script-nosandbox" label="&NoSandboxMode;" />
+        </groupbox>
       </vbox>
     </tabpanel>
   </tabpanels>

--- a/content/scriptprefs.xul
+++ b/content/scriptprefs.xul
@@ -14,9 +14,11 @@
 ]>
 
 <dialog xmlns="http://www.mozilla.org/keymaster/gatekeeper/there.is.only.xul"
-  buttons="accept,cancel"
+  buttons="extra1,accept,cancel"
   title="&scriptprefs.title;"
   ondialogaccept="return onDialogAccept();"
+  buttonlabelextra1="Advanced"
+  ondialogextra1="return onDisplayAdvancedDialog();"
 >
 
 <script type="application/x-javascript" src="chrome://greasemonkey/content/scriptprefs.js" />
@@ -33,10 +35,6 @@
         <cludes id="user-includes"/>
         <label value="&label.grpExcluded;" />
         <cludes id="user-excludes" />
-        <groupbox>
-          <caption label="&UnsafeScripting;" />
-          <checkbox id="user-nosandbox" label="&NoSandboxMode;" />
-        </groupbox>
       </vbox>
     </tabpanel>
     <tabpanel>
@@ -49,10 +47,6 @@
           <label value="&label.grpExcluded;" />
           <cludes id="script-excludes" class="readonly" />
         </vbox>
-        <groupbox>
-          <caption label="&UnsafeScripting;" />
-          <checkbox id="script-nosandbox" label="&NoSandboxMode;" />
-        </groupbox>
       </vbox>
     </tabpanel>
   </tabpanels>

--- a/locale/en-US/gm-cludes.dtd
+++ b/locale/en-US/gm-cludes.dtd
@@ -10,3 +10,5 @@
 <!ENTITY button.remove "Remove">
 <!ENTITY label.grpIncluded "Included Pages">
 <!ENTITY label.grpExcluded "Excluded Pages">
+<!ENTITY label.corsIncluded "CORS Included URL's">
+<!ENTITY label.corsExcluded "CORS Excluded URL's">

--- a/locale/en-US/greasemonkey.dtd
+++ b/locale/en-US/greasemonkey.dtd
@@ -37,6 +37,8 @@
 <!ENTITY SubmitStats "Gather and submit anonymous usage statistics to improve Greasemonkey.">
 <!ENTITY AlsoUninstallPrefs "Also uninstall associated preferences">
 <!ENTITY UpdateChecking "Update Checking">
+<!ENTITY UnsafeScripting "Insecure Mode (allow full, unrestricted DOM and xmlHttpRequest access)">
+<!ENTITY NoSandboxMode "Warning: you should not enable this unless you fully understand the risk.">
 <!ENTITY RequireSecureUpdates "Require secure updates">
 <!ENTITY greasemonkey.noscriptshere "No installed scripts run on this page.">
 <!ENTITY greasemonkey.youhavenoscripts "You don't have any user scripts installed">

--- a/locale/en-US/greasemonkey.dtd
+++ b/locale/en-US/greasemonkey.dtd
@@ -46,3 +46,6 @@
 <!ENTITY scriptprefs.title "Greasemonkey User Script Preferences - !!">
 <!ENTITY scriptprefs.usersettings "User Settings">
 <!ENTITY scriptprefs.scriptsettings "Script Settings">
+<!ENTITY advancedscriptprefs.title "Greasemonkey Advanced User Script Preferences - !!">
+<!ENTITY advancedscriptprefs.usersettings "Advanced User Settings">
+<!ENTITY advancedscriptprefs.scriptsettings "Advanced Script Settings">

--- a/locale/en-US/greasemonkey.properties
+++ b/locale/en-US/greasemonkey.properties
@@ -2,6 +2,7 @@ extensions.{e4a8a97b-f2ed-450b-b12d-ee082ba24781}.description=A User Script Mana
 error.access-violation=Greasemonkey access violation: unsafeWindow cannot call %1.
 error.args.getValue=Unsupported type for GM_setValue. Supported types are: string, bool, and 32 bit integers.
 error.args.setValue=GM_setValue must specify two arguments: name and value.
+error.corsAccessDenied=Greasemonkey access violation: CORS policy does not permit access to URL %1.
 error.disallowedScheme=Disallowed scheme in URL: %1
 error.downloadingUrl=Error downloading URL:
 error.invalidUrl=Invalid URL: %1

--- a/modules/parseScript.js
+++ b/modules/parseScript.js
@@ -105,6 +105,10 @@ function parse(aSource, aUri, aFailWhenMissing, aNoMetaOk) {
             );
       }
       break;
+    case 'nosandbox':
+      script['_' + header] = typeof(value) === 'undefined' ?
+                             true : value == true.toString();
+      break;
     case 'require':
       try {
         var reqUri = GM_util.uriFromUrl(value, aUri);

--- a/modules/parseScript.js
+++ b/modules/parseScript.js
@@ -65,6 +65,12 @@ function parse(aSource, aUri, aFailWhenMissing, aNoMetaOk) {
       script['_' + header] = value;
       break;
 
+    case 'corsExclude':
+      script._corsExcludes.push(value);
+      break;
+    case 'corsInclude':
+      script._corsIncludes.push(value);
+      break;
     case 'installURL':
       header = 'downloadURL';
     case 'downloadURL':

--- a/modules/script.js
+++ b/modules/script.js
@@ -44,6 +44,7 @@ function Script(configNode) {
   this._modifiedTime = null;
   this._name = 'user-script';
   this._namespace = '';
+  this._nosandbox = false;
   this._prefroot = null;
   this._rawMeta = '';
   this._requires = [];
@@ -110,6 +111,9 @@ function Script_getName() { return this._name; });
 
 Script.prototype.__defineGetter__('namespace',
 function Script_getNamespace() { return this._namespace; });
+
+Script.prototype.__defineGetter__('nosandbox',
+  function Script_getNosandbox() { return this._nosandbox; });
 
 Script.prototype.__defineGetter__('id',
 function Script_getId() {
@@ -355,6 +359,7 @@ Script.prototype._loadFromConfigNode = function(node) {
   this._runAt = node.getAttribute("runAt") || "document-end"; // legacy default
   this.icon.fileURL = node.getAttribute("icon");
   this._enabled = node.getAttribute("enabled") == true.toString();
+  this._nosandbox = node.getAttribute("nosandbox") == true.toString();
 };
 
 Script.prototype.toConfigNode = function(doc) {
@@ -423,6 +428,7 @@ Script.prototype.toConfigNode = function(doc) {
   scriptNode.setAttribute("runAt", this._runAt);
   scriptNode.setAttribute("uuid", this._uuid);
   scriptNode.setAttribute("version", this._version);
+  scriptNode.setAttribute("nosandbox", this._nosandbox);
 
   if (this._downloadURL) {
     scriptNode.setAttribute("installurl", this._downloadURL);
@@ -474,6 +480,7 @@ Script.prototype.info = function() {
       'matches': matches,
       'name': this.name,
       'namespace': this.namespace,
+      'nosandbox': this.nosandbox,
       // 'requires': ???,
       'resources': resources,
       'run-at': this.runAt,
@@ -568,6 +575,7 @@ Script.prototype.updateFromNewScript = function(newScript, safeWin) {
   this._runAt = newScript._runAt;
   this._version = newScript._version;
   this._downloadURL = newScript._downloadURL;
+  this._nosandbox = newScript._nosandbox;
   this.updateURL = newScript.updateURL;
 
   this.showGrantWarning();

--- a/modules/script.js
+++ b/modules/script.js
@@ -45,6 +45,7 @@ function Script(configNode) {
   this._name = 'user-script';
   this._namespace = '';
   this._nosandbox = false;
+  this._userNosandbox = false;
   this._prefroot = null;
   this._rawMeta = '';
   this._requires = [];
@@ -114,6 +115,13 @@ function Script_getNamespace() { return this._namespace; });
 
 Script.prototype.__defineGetter__('nosandbox',
   function Script_getNosandbox() { return this._nosandbox; });
+Script.prototype.__defineSetter__('nosandbox',
+  function Script_setNosandbox(nosandbox) { this._nosandbox = nosandbox; });
+
+Script.prototype.__defineGetter__('userNosandbox',
+  function Script_getUserNosandbox() { return this._userNosandbox; });
+Script.prototype.__defineSetter__('userNosandbox',
+  function Script_setUserNosandbox(userNosandbox) { this._userNosandbox = userNosandbox; });
 
 Script.prototype.__defineGetter__('id',
 function Script_getId() {
@@ -360,6 +368,7 @@ Script.prototype._loadFromConfigNode = function(node) {
   this.icon.fileURL = node.getAttribute("icon");
   this._enabled = node.getAttribute("enabled") == true.toString();
   this._nosandbox = node.getAttribute("nosandbox") == true.toString();
+  this._userNosandbox = node.getAttribute("userNosandbox") == true.toString();
 };
 
 Script.prototype.toConfigNode = function(doc) {
@@ -429,6 +438,7 @@ Script.prototype.toConfigNode = function(doc) {
   scriptNode.setAttribute("uuid", this._uuid);
   scriptNode.setAttribute("version", this._version);
   scriptNode.setAttribute("nosandbox", this._nosandbox);
+  scriptNode.setAttribute("userNosandbox", this._userNosandbox);
 
   if (this._downloadURL) {
     scriptNode.setAttribute("installurl", this._downloadURL);
@@ -481,6 +491,7 @@ Script.prototype.info = function() {
       'name': this.name,
       'namespace': this.namespace,
       'nosandbox': this.nosandbox,
+      'userNosandbox': this.userNosandbox,
       // 'requires': ???,
       'resources': resources,
       'run-at': this.runAt,
@@ -566,7 +577,7 @@ Script.prototype.updateFromNewScript = function(newScript, safeWin) {
   }
 
   // Copy new values.
-  //  NOTE: User 'cludes are _not_ copied!  They should remain as-is.
+  //  NOTE: User 'cludes  / nosandbox are _not_ copied!  They should remain as-is.
   this._excludes = newScript._excludes;
   this._grants = newScript._grants;
   this._includes = newScript._includes;


### PR DESCRIPTION
These two commits add:

  (1) a @nosandbox option to user scripts which, when enabled, allows execution with full DOM _and_ xmlHttpRequest access
  (2) a per-script userNosandbox option (similar to User Includes/Excludes) that a user must check in order to allow the @nosandbox option before it is actually enabled

In other words, the first commit enables @nosandbox in user scripts and any script with @nosandbox set to true runs without the typical access wrapping (i.e., window == unsafeWindow) and has full access to all granted GM_* functions.  The second commit makes @nosandbox a per-script user option that is off by default; if both @nosandbox and the script.userNosandbox options are not true, the current ("as safe as possible") behavior holds.

Having followed some of the discussions here and on the mailing list, I understand the need for sandboxing user scripts and respect your efforts at implementing better GM security.  However, there are many cases when full DOM and AJAX request access is a requirement and I do not see a better way than the above two commits at allowing this and still pleasing everyone (please correct me if I am wrong here).

For instance, the main use case is typically something like: you fully trust the site you are running GM on (e.g., you may even have full source access) but for corporate, administrative or political reasons, you simply cannot get any changes to the site implemented.

Please consider these two commits for addition into a future GreaseMonkey release.

Thanks!

John