### PR TITLE
__exposedProps__ was not set on GM_xmlhttpRequest's abort function

### DIFF
--- a/modules/xmlhttprequester.js
+++ b/modules/xmlhttprequester.js
@@ -56,7 +56,8 @@ GM_xmlhttpRequester.prototype.contentStartRequest = function(details) {
         responseHeaders: "r",
         responseText: "r",
         status: "r",
-        statusText: "r"
+        statusText: "r",
+        abort: "r"
         },
     abort: function () { return req.abort(); }
   };


### PR DESCRIPTION
GM_xmlhttpRequest() was not returning the abort() function as specified in http://wiki.greasespot.net/GM_xmlhttpRequest#Returns .

See also, http://stackoverflow.com/q/14185249/331508
