### PR TITLE
Remove bashism from build.sh

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -34,7 +34,7 @@ if [ "official" != "$1" ]; then
   rm tmp
 fi
 
-if [ "bz" == "$1" ]; then
+if [ "bz" = "$1" ]; then
   # For babelzilla, only include en-US locale.
   rm -r `find locale -type d -not -name locale -a -not -name en-US`
 fi


### PR DESCRIPTION
Probably shouldn't have a bashism in a file with `#!/bin/sh` at the top.
