### PR TITLE
Add script source to GM_info

### DIFF
--- a/modules/script.js
+++ b/modules/script.js
@@ -481,6 +481,7 @@ Script.prototype.info = function() {
       'version': this.version,
     },
     'scriptMetaStr': extractMeta(this.textContent),
+    'scriptSource': this.textContent,
   }
 };
 


### PR DESCRIPTION
Consider issue #1529, where the proposed solution is to bootstrap their coffeescript compilation with a few lines of JS. However, when uploading to userscripts.org it feels neater to have things in one file but there's (currently) only one way to do this for #1529, and that's to turn the coffeescript into a JS string.

As JS does not have any multiline strings this either means one massively long line or ugly splits at wrapping boundaries. This is not an acceptable solution, as it makes inline editing near-impossible.

This proposal allows direct access to the script source meaning one could define a 'custom metadata' block (really just a block comment with some searchable strings) like

``` javascript
/*
COFFEE_START
alert "I knew it!" if true?
COFFEE_END
*/
```

which you can then extract with a regular expression (or String.indexOf) and pass to an included compiler. You now allow inline editing.

This additionally makes it easier to have CSS styles and HTML fragments inline in the userscript.  
HTML fragments are particularly important if (for example) wanting to use an MVC framework like angularjs or a templating engine like mustache/handlebars - it's tiresome having to build a template with JS to then convert it to HTML and makes editing more difficult. This would allow you to have html fragments in your userscript to be loaded as strings at initialisation, an inline getResourceText if you like to think of it like that.

(thinking about it, the inline getResourceText is an interesting idea but I consider this a more fundamental and flexible idea)

The chosen name of the property (scriptSource) is compatible with tampermonkey.
