### PR TITLE
Various addon manager related fixes

### DIFF
--- a/modules/addons4.js
+++ b/modules/addons4.js
@@ -325,6 +325,7 @@ ScriptInstall.prototype.install = function() {
           'onDownloadFailed', this._listeners, this);
     }
   }));
+  this._remoteScript = rs;
 };
 
 ScriptInstall.prototype._progressCallback = function(


### PR DESCRIPTION
- The first commit makes sure all required arguments are passed to the corresponding `InstallListener`s as described on [MDN](https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/Add-on_Manager/InstallListener).
- The second commit adds a comment to the `RemoteScript#install` call describing that this call also replaces the cached `ScriptAddon` object, thus explaining why the cached object can be used below.
- The third commit properly sets `this._remoteScript` in `ScriptInstall#install`, so that `ScriptInstall#cancel` can actually call `this._remoteScript.cleanup()` when called.
