### PR TITLE
Convert http-USO to https-USO to enable updating

### DIFF
--- a/modules/parseScript.js
+++ b/modules/parseScript.js
@@ -70,6 +70,9 @@ function parse(aSource, aUri, aFailWhenMissing, aNoMetaOk) {
     case 'downloadURL':
     case 'updateURL':
       try {
+        if (value) {
+          value = value.replace(/^http(:\/\/userscripts\.org\/)/i, 'https$1');
+        }
         var uri = GM_util.uriFromUrl(value, aUri || this._downloadURL);
         script['_' + header] = uri.spec;
       } catch (e) {

--- a/modules/script.js
+++ b/modules/script.js
@@ -134,7 +134,7 @@ Script.prototype.__defineGetter__('description',
 function Script_getDescription() { return this._description; });
 
 Script.prototype.__defineGetter__('downloadURL',
-    function Script_getDescription() { return '' + this._downloadURL; });
+function Script_getDownloadURL() { return '' + this._downloadURL; });
 
 Script.prototype.__defineGetter__('uuid',
 function Script_getUuid() { return this._uuid; });
@@ -487,6 +487,9 @@ Script.prototype.isRemoteUpdateAllowed = function(aForced) {
   if (!aForced) {
     if (!this.enabled) return false;
     if (this._modifiedTime > this._installTime) return false;
+  }
+  if (/^https?:\/\/userscripts\.org\//.test(this._downloadURL)) {
+    return true;
   }
 
   var ioService = Components.classes["@mozilla.org/network/io-service;1"]


### PR DESCRIPTION
Several scripts are stuck at an old version because their downloadURL points to the http-version of USO instead of https, while `extension.greasemonkey.requireSecureUpdates` is set to true by default.

Since it is known in advance that USO is able to server content over https, we can safely convert all USO downloadURLs to the https-version.

The limitation that has been fixed affects over 6k scripts:
- [site:userscripts.org/scripts/review "@downloadURL http://userscripts.org/"](https://www.google.nl/search?q=site%3Auserscripts.org%2Fscripts%2Freview+%22%40downloadURL+http%3A%2F%2Fuserscripts.org%2F%22) - 6110 results
- [site:userscripts.org/scripts/review "@updateURL http://userscripts.org/"](https://www.google.nl/search?q=site%3Auserscripts.org%2Fscripts%2Freview+%22%40updateURL+http%3A%2F%2Fuserscripts.org%2F%22) - 13800 results.
