### PR TITLE
Fixed correct setting value for newScript template

### DIFF
--- a/content/options.js
+++ b/content/options.js
@@ -31,6 +31,6 @@ function GM_saveOptions(checkbox) {
       document.getElementById('globalExcludes').pages;
   GM_prefRoot.setValue('newScript.removeUnused',
       !!document.getElementById('newScript-removeUnused').checked);
-  GM_prefRoot.getValue('newScript.template',
+  GM_prefRoot.setValue('newScript.template',
       document.getElementById('newScript-template').value);
 }


### PR DESCRIPTION
Thanks to Marti for [pointing out](http://userscripts.org/topics/127434?page=1#posts-514706) a bug in saving a new script template in the modified upstream pull.
