### PR TITLE
Remove ScriptChannel

### DIFF
--- a/components/scriptProtocol.js
+++ b/components/scriptProtocol.js
@@ -93,9 +93,4 @@ ScriptProtocol.prototype.newChannel = function(aUri) {
   return new DummyChannel(aUri);
 };
 
-const components = [ScriptProtocol];
-if ("generateNSGetFactory" in XPCOMUtils) {
-  var NSGetFactory = XPCOMUtils.generateNSGetFactory(components); // Gecko 2.0+
-} else {
-  var NSGetModule = XPCOMUtils.generateNSGetModule(components); // Gecko 1.9.x
-}
+var NSGetFactory = XPCOMUtils.generateNSGetFactory([ScriptProtocol]);


### PR DESCRIPTION
Since 1999be3484154d22f41afba465fb56366e6cf61b, the `ScriptChannel` hasn't been used anymore to get access to a script's content. However, it was still accessible to userscripts: If a resource was defined with a name ending in `.user.js`, `GM_getResourceText("example.user.js")` would work as expected (i.e. it would return the resource content), whereas accessing the URI returned by `GM_getResourceURL("example.user.js")`  would return the parent script's content.

An example script showing this unexpected behavior can be found in this gist: https://gist.github.com/Ventero/8640014

Thus, the special behavior of `greasemonkey-script:foo.user.js` URIs should be removed.
