### PR TITLE
Delay importing the actual sync service.

### DIFF
--- a/modules/sync.js
+++ b/modules/sync.js
@@ -18,7 +18,6 @@ var gSyncInitialized = false;
 var gWeave = {};
 Cu.import('resource://services-sync/engines.js', gWeave);
 Cu.import('resource://services-sync/record.js', gWeave);
-Cu.import('resource://services-sync/service.js', gWeave);
 Cu.import('resource://services-sync/status.js', gWeave);
 Cu.import('resource://services-sync/util.js', gWeave);
 
@@ -38,7 +37,9 @@ var SyncServiceObserver = {
 
     // This must be delayed until after the Greasemonkey service is set up.
     Cu.import('resource://greasemonkey/remoteScript.js');
-
+    // Also delay importing the actual Sync service to prevent conflicts with
+    // the master password dialog during browser startup. See #1852.
+    Cu.import('resource://services-sync/service.js', gWeave);
     gWeave.Service.engineManager.register(ScriptEngine);
   },
 


### PR DESCRIPTION
This should prevent conflicts with the master password dialog showing up during browser startup (see #1852).

I can't actually reproduce the problem (neither with MP+ installed, nor without), but this patch fixed the problem for a user in the #greasemonkey IRC channel (thanks topdownjimmy for testing!).
