### PR TITLE
GM_addStyle now returns the added element

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -111,7 +111,7 @@ function createSandbox(
   }
 
   if (GM_util.inArray(aScript.grants, 'GM_addStyle')) {
-    sandbox.GM_addStyle = function(css) { GM_addStyle(aContentWin.document, css)};
+    sandbox.GM_addStyle = GM_util.hitch(null, GM_addStyle, aContentWin.document);
   }
   if (GM_util.inArray(aScript.grants, 'GM_log')) {
     sandbox.GM_log = GM_util.hitch(new GM_ScriptLogger(aScript), 'log');


### PR DESCRIPTION
When GM_addStyle was added to the sandbox, it was wrapped in such a way as to discard the element returned by the GM_addStyle implementation. This patch converts the wrapper to a standard GM_util.hitch. This will save folks from having to resort to more complicated methods to find the added stylesheet.
