### PR TITLE
Add option to allow 'data:' URLs to be Greaseable

### DIFF
--- a/defaults/preferences/greasemonkey.js
+++ b/defaults/preferences/greasemonkey.js
@@ -1,5 +1,6 @@
 pref("extensions.{e4a8a97b-f2ed-450b-b12d-ee082ba24781}.description", "chrome://greasemonkey/locale/greasemonkey.properties");
 pref("extensions.greasemonkey.coralCacheWorks", true);
+pref("extensions.greasemonkey.dataIsGreaseable", false);
 pref("extensions.greasemonkey.enableScriptRefreshing", true);
 pref("extensions.greasemonkey.fileIsGreaseable", false);
 pref("extensions.greasemonkey.globalExcludes", '[]');

--- a/modules/util/isGreasemonkeyable.js
+++ b/modules/util/isGreasemonkeyable.js
@@ -18,6 +18,8 @@ function isGreasemonkeyable(url) {
       if (/^about:blank/.test(url)) return true;
       // Never allow the rest of "about:".  See #1375.
       return false;
+    case "data":
+      return GM_prefRoot.getValue('dataIsGreaseable');
     case "file":
       return GM_prefRoot.getValue('fileIsGreaseable');
     case "unmht":


### PR DESCRIPTION
This change creates an option 'dataIsGreaseable' to allow 'data:' URLs to be greaseable the way that fileIsGreaseable does for 'file:' URLs.  The default value is false to continue not allowing data URLs to be greaseable for standard usage.
