### PR TITLE
GM_openInTab with insertRelatedAfterCurrent = true (frame, iframe)

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -199,7 +199,7 @@ function openInTab(safeContentWin, url, aLoadInBackground) {
   var chromeWin = getChromeWinForContentWin(safeContentWin);
   var browser = chromeWin.gBrowser;
   var currentTab = browser.tabs[
-      browser.getBrowserIndexForDocument(safeContentWin.document)];
+      browser.getBrowserIndexForDocument(safeContentWin.top.document)];
   var newTab = browser.loadOneTab(
       uri.spec, {'inBackground': aLoadInBackground});
   var newWin = GM_windowForTab(newTab, browser);


### PR DESCRIPTION
Ad https://github.com/greasemonkey/greasemonkey/issues/1897
(.top of a window is topmost window, even if it is already topmost window)
