### PR TITLE
Correctly handle missing origin URL.

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -361,7 +361,7 @@ service.prototype.shouldLoad = function(ct, cl, org, ctx, mt, ext) {
   }
 
   // Do not install scripts when the origin URL "is a script".  See #1875
-  if (org.spec.match(gScriptEndingRegexp)) {
+  if (org && org.spec.match(gScriptEndingRegexp)) {
     return ret;
   }
 


### PR DESCRIPTION
As the [docs for nsIContentPolicy#shouldLoad](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XPCOM/Reference/Interface/nsIContentPolicy#shouldLoad%28%29) say, `aRequestOrigin` can be null. One example for this is the first page load when the browser starts.

The attached commit simply checks for null before trying to access `org`.
