### PR TITLE
@icon missing in GM 2.2 beta 1

### DIFF
--- a/modules/remoteScript.js
+++ b/modules/remoteScript.js
@@ -95,7 +95,8 @@ function DownloadListener(
   this._fileOutputStream = Cc["@mozilla.org/network/file-output-stream;1"]
       .createInstance(Ci.nsIFileOutputStream);
   this._fileOutputStream.init(aFile, -1, -1, null);
-  this._fileOutputStream.write('\u00EF\u00BB\u00BF', 3); // UTF-8 BOM
+  if (aUri.spec.match(/\.user\.js$/))
+    this._fileOutputStream.write('\u00EF\u00BB\u00BF', 3); // UTF-8 BOM
   this._binOutputStream = Cc['@mozilla.org/binaryoutputstream;1']
       .createInstance(Ci.nsIBinaryOutputStream);
   this._binOutputStream.setOutputStream(this._fileOutputStream);


### PR DESCRIPTION
Ad #1990 (#1940, https://github.com/greasemonkey/greasemonkey/commit/ef976d6448b2d2e4d17362d6d627796d0e6799f0 - Insert a UTF-8 BOM to fix "Show script source")
