### PR TITLE
Make check for about:blank URIs more exact.

### DIFF
--- a/modules/script.js
+++ b/modules/script.js
@@ -25,6 +25,7 @@ AddonManager.getAddonByID(GM_GUID, function(addon) {
   gGreasemonkeyVersion = '' + addon.version;
 });
 
+var gAboutBlankRegexp = /^about:blank/;
 
 function Script(configNode) {
   this._observers = [];
@@ -76,9 +77,7 @@ Script.prototype.matchesURL = function(url) {
 
   function testClude(glob) {
     // Do not run in about:blank unless _specifically_ requested.  See #1298
-    if (-1 !== url.indexOf('about:blank')
-        && -1 == glob.indexOf('about:blank')
-    ) {
+    if (gAboutBlankRegexp.test(url) && !gAboutBlankRegexp.test(glob)) {
       return false;
     }
 


### PR DESCRIPTION
Currently, scripts don't run on a window if its location includes `about:blank` anywhere in the URL. This commit fixes the check so it only blocks actual `about:blank` URIs (i.e. those that start with `about:blank`).
