### PR TITLE
Add missing extractMeta import in newscript.js

### DIFF
--- a/content/newscript.js
+++ b/content/newscript.js
@@ -1,3 +1,4 @@
+Components.utils.import('resource://greasemonkey/extractMeta.js');
 Components.utils.import('resource://greasemonkey/parseScript.js');
 Components.utils.import('resource://greasemonkey/prefmanager.js');
 Components.utils.import('resource://greasemonkey/util.js');


### PR DESCRIPTION
Looks like I missed this call to `extractMeta` in 23205fefc4a0cd209eeb2cca8fe5404a78d4fea4. Double-checked now, and this was the only use without import.