### PR TITLE
GM_log truncates at NULL byte (typeof 'string' only)

### DIFF
--- a/modules/miscapis.js
+++ b/modules/miscapis.js
@@ -244,7 +244,8 @@ GM_ScriptLogger.prototype.consoleService = Components
 
 GM_ScriptLogger.prototype.log = function(message) {
   // https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIConsoleService#logStringMessage() - wstring / wide string
-  message = message.replace(/\0/g, '');
+  if ('string' == typeof message || message instanceof String)
+    message = message.replace(/\0/g, '');
   this.consoleService.logStringMessage(this.prefix + '\n' + message);
 };
 

--- a/modules/miscapis.js
+++ b/modules/miscapis.js
@@ -244,9 +244,7 @@ GM_ScriptLogger.prototype.consoleService = Components
 
 GM_ScriptLogger.prototype.log = function(message) {
   // https://developer.mozilla.org/en-US/docs/XPCOM_Interface_Reference/nsIConsoleService#logStringMessage() - wstring / wide string
-  if ('string' == typeof message || message instanceof String)
-    message = message.replace(/\0/g, '');
-  this.consoleService.logStringMessage(this.prefix + '\n' + message);
+  this.consoleService.logStringMessage((this.prefix + '\n' + message).replace(/\0/g, ''));
 };
 
 // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ // \\ //


### PR DESCRIPTION
The suggestion (for example).

The problem - example:
GM_log(GM_listValues());

Browser Console:
![1](https://cloud.githubusercontent.com/assets/2373486/4932004/0559d9d0-6583-11e4-8641-31db4851afbe.png)
