### PR TITLE
Fix syncing of script storage.

### DIFF
--- a/modules/sync.js
+++ b/modules/sync.js
@@ -137,6 +137,12 @@ ScriptStore.prototype = {
         var names = storage.listValues();
         for (var i = 0, name = null; name = names[i]; i++) {
           var val = storage.getValue(name);
+          try {
+            val = JSON.parse(val);
+          } catch (e) {
+            dump('JSON parse error? ' + uneval(e) + '\n');
+            continue;
+          }
           record.cleartext.values[name] = val;
           totalSize += name.length;
           totalSize += val.length || 4;  // 4 for number / bool (no length).


### PR DESCRIPTION
Since GM_ScriptStorageBack.getValue now returns a JSONified value which is parsed on the frontend, this needs a `JSON.parse`.  Currently (version 3.1beta1) it's breaking script values (`5` to `"5"`, `'foo'` to `'"foo"'`) if `extensions.greasemonkey.sync.values` is turned on.
