### PR TITLE
Remove "installPolicy shouldProcess()" debug line

### DIFF
--- a/modules/installPolicy.js
+++ b/modules/installPolicy.js
@@ -115,7 +115,6 @@ var InstallPolicy = {
   },
 
   shouldProcess: function() {
-    dump('>>> installPolicy shouldProcess() ...\n');
     return Ci.nsIContentPolicy.ACCEPT;
   },
 


### PR DESCRIPTION
I've noticed this debug message gets printed a lot when viewing YouTube videos or possibly visiting other sites with Flash objects.