### PR TITLE
Display and edit @match rules in 'clude editor - fix

### DIFF
--- a/skin/bindings.css
+++ b/skin/bindings.css
@@ -1,9 +1,15 @@
 cludes {
-  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-editable')
+  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-editable');
 }
-.in cludes.readonly {
-  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-readonly-in')
+.include cludes.readonly {
+  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-readonly-include');
 }
-.ex cludes.readonly {
-  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-readonly-ex')
+.match cludes.readonly {
+  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-readonly-match');
+}
+#vboxUserCludeMatch #btnUserClude {
+  visibility: hidden;
+}
+.exclude cludes.readonly {
+  -moz-binding: url('chrome://greasemonkey/content/bindings.xml#clude-editor-readonly-exclude');
 }


### PR DESCRIPTION
Add https://github.com/greasemonkey/greasemonkey/commit/4d5039598c8f929da89477334ebcae5cc1444a80

Repair pull request (@matchInCludeEditorEditing #2126) for #1703.

__My mistake, I'm sorry.__