### PR TITLE
fix issue #2043: Feature: Execute scripts on demand

### DIFF
--- a/content/browser.xul
+++ b/content/browser.xul
@@ -109,6 +109,14 @@
     </menupopup>
   </menu>
 
+  <popupset id="mainPopupSet">
+    <panel id="mc-panel" noautohide="false" noautofocus="true" position="topcenter topright">
+      <textbox id="mc-entry"/>
+      <listbox id="mc-list">
+      </listbox>
+    </panel>
+  </popupset>
+
   <stringbundleset id="stringbundleset">
   <stringbundle id="gm-browser-bundle" src="chrome://greasemonkey/locale/gm-browser.properties" />
   </stringbundleset>

--- a/skin/browser.css
+++ b/skin/browser.css
@@ -25,3 +25,27 @@ toolbar[iconsize="small"] #greasemonkey-tbb {
 {
   list-style-image: url("chrome://greasemonkey/skin/icon32.png");
 }
+
+#mc-panel,
+#mc-entry,
+#mc-list {
+  -moz-appearance: none;
+  outline: none;
+  margin: 0;
+  border: 1px solid #d2d2d2;
+  border-radius: 10px;
+  padding: 10px;
+}
+
+#mc-panel {
+  background-color: rgba(255,255,255,.8);
+  width: 320px;
+  height: 50px;
+}
+
+#mc-entry,
+#mc-list {
+  background-color: #fff;
+  font: 20px/1.4 Arial, sans-serif;
+  margin: 5px 0;
+}


### PR DESCRIPTION
This adds a floating panel that displays all available menu commands for the current page.
The floating panel can be activated by pressing CTRL+SHIFT+SPACE.

User can filter available menu commands by typing a few characters into the text field, and any menu command whose name contains those characters will be displayed.
The first menu command from the list will be selected and ready to execute upon hitting Enter.
User can navigate the list up and down using arrows while still have the text box focused for further filtering.

The following screenshot shows how the floating panel looks like. Also, it demonstrates the ability to execute Pinboard bookmarklet -which Firefox no longer allows it to run due to a security issue- after turning it into a menu command script.
![screenshot](https://cloud.githubusercontent.com/assets/4025925/7441237/47f5ff2c-f0e7-11e4-83b6-1ac92af7e6fd.png)
