### PR TITLE
Fix height of script settings window for Full HD and lower screen sizes

### DIFF
--- a/skin/scriptprefs.css
+++ b/skin/scriptprefs.css
@@ -1,3 +1,9 @@
 cludes {
   min-width: 500px;
 }
+
+@media (max-height: 1080px) {
+  cludes {
+    max-height: 150px;
+  }
+}


### PR DESCRIPTION
I was unable to see full window on my HD resolution screen because of big size of lists in cludes tag. So I decided to add fixed max-height for low resolutions and used 25% of SVGA height.