### PR TITLE
GM 3.2+: GM_openInTab(url, false) - open the page in the background

### DIFF
--- a/content/browser.js
+++ b/content/browser.js
@@ -81,8 +81,8 @@ GM_BrowserUI.openInTab = function(aMessage) {
 
   var prefBg = getBool('browser.tabs.loadInBackground');
   prefBg = (aMessage.data.inBackground === null)
-           ? prefBg
-           : aMessage.data.inBackground;
+      ? prefBg
+      : aMessage.data.inBackground;
   if (scriptTabIsCurrentTab && !prefBg) tabBrowser.selectedTab = newTab;
 
   var prefRel = getBool('browser.tabs.insertRelatedAfterCurrent');

--- a/content/browser.js
+++ b/content/browser.js
@@ -80,7 +80,9 @@ GM_BrowserUI.openInTab = function(aMessage) {
   var getBool = Services.prefs.getBoolPref;
 
   var prefBg = getBool('browser.tabs.loadInBackground');
-  prefBg |= aMessage.data.inBackground;
+  prefBg = (aMessage.data.inBackground === null)
+           ? prefBg
+           : aMessage.data.inBackground;
   if (scriptTabIsCurrentTab && !prefBg) tabBrowser.selectedTab = newTab;
 
   var prefRel = getBool('browser.tabs.insertRelatedAfterCurrent');


### PR DESCRIPTION
``` javascript
// browser.tabs.loadInBackground = true
GM_openInTab(url, false); // open the page in the background
```

The suggestion (for example).
