### PR TITLE
Disable e10s shims

### DIFF
--- a/install.rdf
+++ b/install.rdf
@@ -12,6 +12,7 @@
     <em:optionsURL>chrome://greasemonkey/content/options.xul</em:optionsURL>
     <em:iconURL>chrome://greasemonkey/skin/icon32.png</em:iconURL>
     <em:type>2</em:type>
+    <em:multiprocessCompatible>true</em:multiprocessCompatible>
 
     <em:name>Greasemonkey</em:name>
     <em:description>A User Script Manager for Firefox</em:description>


### PR DESCRIPTION
See https://developer.mozilla.org/en-US/Add-ons/Install_Manifests#multiprocessCompatible

It shouldn't affect users on the FF release branch and uncover any remaining compatibility issues for e10s testers.

It worksforme(tm), but that of course is no guarantee.

Is there any better way to test than just visiting pages with a script installed?