### PR TITLE
avoid duplication of source strings

### DIFF
--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -1,6 +1,5 @@
 var EXPORTED_SYMBOLS = ['IPCScript'];
 
-Components.utils.import("chrome://greasemonkey-modules/content/extractMeta.js");
 Components.utils.import("chrome://greasemonkey-modules/content/util.js");
 
 function IPCScript(aScript, addonVersion) {
@@ -17,15 +16,13 @@ function IPCScript(aScript, addonVersion) {
   this.namespace = aScript.namespace;
   this.noframes = aScript.noframes;
   this.runAt = aScript.runAt;
-  this.textContent = aScript.textContent;
   this.uuid = aScript.uuid;
   this.version = aScript.version;
   this.willUpdate = aScript.isRemoteUpdateAllowed();
 
   this.requires = aScript.requires.map(function(req) {
     return {
-      'fileURL': req.fileURL,
-      'textContent': req.textContent
+      'fileURL': req.fileURL
     };
   });
 
@@ -33,20 +30,10 @@ function IPCScript(aScript, addonVersion) {
     return {
       'name': res.name,
       'mimetype': res.mimetype,
-      'textContent': res.textContent,
       'url': GM_util.getUriFromFile(res.file).spec
     };
   });
 };
-
-IPCScript.prototype.__defineGetter__('metaStr',
-function IPCScript_getMetaStr() {
-  if (!this._metaStr) {
-    this._metaStr = extractMeta(this.textContent);
-  }
-
-  return this._metaStr;
-});
 
 IPCScript.prototype.info = function() {
   var resources = {};
@@ -60,8 +47,6 @@ IPCScript.prototype.info = function() {
   return {
     'uuid': this.uuid,
     'version': this.addonVersion,
-    'scriptMetaStr': this.metaStr,
-    'scriptSource': this.textContent,
     'scriptWillUpdate': this.willUpdate,
     'script': {
       'description': this.description,

--- a/modules/miscapis.js
+++ b/modules/miscapis.js
@@ -24,8 +24,13 @@ GM_Resources.prototype.getResourceURL = function(aScript, name) {
   return ['greasemonkey-script:', aScript.uuid, '/', name].join('');
 };
 
+
 GM_Resources.prototype.getResourceText = function(name) {
-  return this._getDep(name).textContent;
+  var dep = this._getDep(name)
+  if(dep.textContent !== undefined)
+    return dep.textContent;
+  // lazy resources in IPC scripts
+  return GM_util.fileXHR(dep.url, "text/plain");
 };
 
 GM_Resources.prototype._getDep = function(name) {

--- a/modules/util.js
+++ b/modules/util.js
@@ -27,6 +27,7 @@ XPCOMUtils.defineLazyModuleGetter(GM_util, 'alert', 'chrome://greasemonkey-modul
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'compareFirefoxVersion', 'chrome://greasemonkey-modules/content/util/compareFirefoxVersion.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'emptyEl', 'chrome://greasemonkey-modules/content/util/emptyEl.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'enqueueRemoveFile', 'chrome://greasemonkey-modules/content/util/enqueueRemoveFile.js');
+XPCOMUtils.defineLazyModuleGetter(GM_util, 'fileXHR', 'chrome://greasemonkey-modules/content/util/fileXHR.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'findMessageManager', 'chrome://greasemonkey-modules/content/util/findMessageManager.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'getBestLocaleMatch', 'chrome://greasemonkey-modules/content/util/getBestLocaleMatch.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'getBinaryContents', 'chrome://greasemonkey-modules/content/util/getBinaryContents.js');

--- a/modules/util/fileXHR.js
+++ b/modules/util/fileXHR.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var EXPORTED_SYMBOLS = ['fileXHR'];
+
+Components.utils.importGlobalProperties(["XMLHttpRequest"]);
+
+// sync XHR. it's just meant to fetch file:// uris that aren't otherwise accessible in content
+// don't use it in the parent process or for web URLs
+function fileXHR(uri, mimetype) {
+  var xhr = new XMLHttpRequest();
+  xhr.open("open", uri, false);
+  xhr.overrideMimeType(mimetype);
+  xhr.send(null);  
+  return xhr.responseText;
+}


### PR DESCRIPTION
Currently script sources get cloned into every sandbox in which a script runs via the `GM_info` structure. Since script sources can be fairly large this results in quite some memory overhead.

Additionally in e10s the scripts are passed down via IPC as new string instances every time they're needed, thus resulting in duplication even before the `GM_info` instances are created.

I've solved that by de-duping identical string instances in `IPCScript` and by installing a cross-compartment getter for the `GM_info.scriptSource` property.

Should lead to significant memory reductions, especially for large scripts and/or scripts that get loaded into every tab and frame.