### PR TITLE
Add contributing guide

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,4 @@
+Please read the [Greasemonkey Programming Style Guide][style-guide] and [Contributing To Greasemonkey][contributing-guide] pages before sending in pull requests.
+
+[style-guide]: http://greasemonkey.github.io/style.html
+[contributing-guide]: http://greasemonkey.github.io/contrib.html


### PR DESCRIPTION
Based on https://github.com/blog/1184-contributing-guidelines and links
to the current Greasemonkey style guide and contributing guide.

This should hopefully help new contributors that don't know where to find the current style guide.