### PR TITLE
[e10s]: newChannelFromURI - it sometimes throws the error

### DIFF
--- a/modules/remoteScript.js
+++ b/modules/remoteScript.js
@@ -10,6 +10,7 @@ Components.utils.import('chrome://greasemonkey-modules/content/scriptIcon.js');
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
 
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
+Components.utils.import("resource://gre/modules/Services.jsm");
 
 var GM_config = GM_util.getService().config;
 var ioService = Cc['@mozilla.org/network/io-service;1']
@@ -578,7 +579,14 @@ RemoteScript.prototype._downloadFile = function(
     }
   }
 
-  var channel = ioService.newChannelFromURI(aUri);
+  var channel = null;
+  if (ioService.newChannelFromURI2) {
+    channel = ioService.newChannelFromURI2(
+        aUri, null, Services.scriptSecurityManager.getSystemPrincipal(),
+        null, Ci.nsILoadInfo.SEC_NORMAL, Ci.nsIContentPolicy.TYPE_OTHER);
+  } else {
+    channel = ioService.newChannelFromURI(aUri);
+  }
   channel.loadFlags |= channel.LOAD_BYPASS_CACHE;
   this._channels.push(channel);
   var dsl = new DownloadListener(

--- a/modules/scriptProtocol.js
+++ b/modules/scriptProtocol.js
@@ -1,6 +1,7 @@
 var EXPORTED_SYMBOLS = ['initScriptProtocol'];
 
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
+Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
 
 var Cc = Components.classes;
@@ -147,7 +148,15 @@ var ScriptProtocol = {
           // In parent scope we have the raw script, with file intact.
           uri = GM_util.getUriFromFile(resource.file);
         }
-        return ioService.newChannelFromURI(uri);
+        var channel = null;
+        if (ioService.newChannelFromURI2) {
+          channel = ioService.newChannelFromURI2(
+              uri, null, Services.scriptSecurityManager.getSystemPrincipal(),
+              null, Ci.nsILoadInfo.SEC_NORMAL, Ci.nsIContentPolicy.TYPE_OTHER);
+        } else {
+          channel = ioService.newChannelFromURI(uri);
+        }
+        return channel;
       }
     }
 

--- a/modules/util/getBinaryContents.js
+++ b/modules/util/getBinaryContents.js
@@ -1,3 +1,4 @@
+Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
 
 var EXPORTED_SYMBOLS = ['getBinaryContents'];
@@ -5,8 +6,17 @@ var EXPORTED_SYMBOLS = ['getBinaryContents'];
 var ioService = Components.classes["@mozilla.org/network/io-service;1"]
     .getService(Components.interfaces.nsIIOService);
 
-function getBinaryContents(file) {
-  var channel = ioService.newChannelFromURI(GM_util.getUriFromFile(file));
+function getBinaryContents(aFile) {
+  var channel = null;
+  if (ioService.newChannelFromURI2) {
+    channel = ioService.newChannelFromURI2(
+        GM_util.getUriFromFile(aFile), null,
+        Services.scriptSecurityManager.getSystemPrincipal(), null,
+        Components.interfaces.nsILoadInfo.SEC_NORMAL,
+        Components.interfaces.nsIContentPolicy.TYPE_OTHER);
+  } else {
+    channel = ioService.newChannelFromURI(GM_util.getUriFromFile(aFile));
+  }
   var input = channel.open();
 
   var bstream = Components.classes["@mozilla.org/binaryinputstream;1"]

--- a/modules/util/getContents.js
+++ b/modules/util/getContents.js
@@ -1,3 +1,4 @@
+Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
 
 var EXPORTED_SYMBOLS = ['getContents'];
@@ -18,7 +19,16 @@ function getContents(aFile, aCharset, aFatal) {
   }
   unicodeConverter.charset = aCharset || 'UTF-8';
 
-  var channel = ioService.newChannelFromURI(GM_util.getUriFromFile(aFile));
+  var channel = null;
+  if (ioService.newChannelFromURI2) {
+    channel = ioService.newChannelFromURI2(
+        GM_util.getUriFromFile(aFile), null,
+        Services.scriptSecurityManager.getSystemPrincipal(), null,
+        Components.interfaces.nsILoadInfo.SEC_NORMAL,
+        Components.interfaces.nsIContentPolicy.TYPE_OTHER);
+  } else {
+    channel = ioService.newChannelFromURI(GM_util.getUriFromFile(aFile));
+  }
   try {
     var input = channel.open();
   } catch (e) {


### PR DESCRIPTION
Ad #2202
The suggestion (for example).
__It is necessary to test all options (e.g.: correct permissions / the correct principal?)!__

![error](https://cloud.githubusercontent.com/assets/2373486/9423616/6135546e-48cc-11e5-8dd4-87a96a67587d.png)

nsIOService::NewChannelFromURI is deprecated:
https://hg.mozilla.org/mozilla-central/file/66a72727e1b3/netwerk/base/nsIOService.cpp#l603

Unfortunately, there are no references to the "NewChannelFromURI2" APIs in the documentation...

The short documentation:
https://hg.mozilla.org/mozilla-central/file/66a72727e1b3/netwerk/base/nsIIOService.idl#l68
