### PR TITLE
avoid sync messages on document load

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -16,6 +16,7 @@ Cu.import("chrome://greasemonkey-modules/content/sync.js");
 Cu.import("chrome://greasemonkey-modules/content/util.js");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
+Cu.import("chrome://greasemonkey-modules/content/refererSetter.js", {});
 
 
 var gStartupHasRun = false;

--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -16,7 +16,6 @@ Cu.import("chrome://greasemonkey-modules/content/sync.js");
 Cu.import("chrome://greasemonkey-modules/content/util.js");
 Cu.import("resource://gre/modules/Services.jsm");
 Cu.import("resource://gre/modules/XPCOMUtils.jsm");
-Cu.import("chrome://greasemonkey-modules/content/refererSetter.js", {});
 
 
 var gStartupHasRun = false;
@@ -31,9 +30,7 @@ var gTmpDir = Components.classes["@mozilla.org/file/directory_service;1"]
 var GM_GUID = "{e4a8a97b-f2ed-450b-b12d-ee082ba24781}";
 var gGreasemonkeyVersion = 'unknown';
 Cu.import("resource://gre/modules/AddonManager.jsm");
-AddonManager.getAddonByID(GM_GUID, function(addon) {
-  gGreasemonkeyVersion = '' + addon.version;
-});
+
 
 /////////////////////// Component-global Helper Functions //////////////////////
 
@@ -57,8 +54,6 @@ function startup(aService) {
       .getService(Ci.nsIMessageListenerManager);
   globalMessageManager.addMessageListener(
       'greasemonkey:script-install', aService.scriptInstall.bind(aService));
-  globalMessageManager.addMessageListener(
-      'greasemonkey:scripts-for-url', aService.getScriptsForUrl.bind(aService));
 
   var scriptValHandler = aService.handleScriptValMsg.bind(aService);
   globalMessageManager.addMessageListener(
@@ -75,6 +70,9 @@ function startup(aService) {
   parentMessageManager.addMessageListener(
       'greasemonkey:scripts-for-uuid',
       aService.getScriptsForUuid.bind(aService));
+  parentMessageManager.addMessageListener("greasemonkey:scripts-update", function(message) {
+    return aService.scriptUpdateData();
+  });
   var mm = Services.ppmm ? Services.ppmm : globalMessageManager;
   mm.addMessageListener(
       'greasemonkey:url-is-temp-file', aService.urlIsTempFile.bind(aService));
@@ -83,6 +81,27 @@ function startup(aService) {
   // Why?  Who knows!?
   globalMessageManager.loadFrameScript(
       'chrome://greasemonkey/content/framescript.js', true);
+  
+
+  
+  // beam down initial set of scripts
+  aService.broadcastScriptUpdates();
+  
+  // notification is async
+  // send the scripts again once we have our version
+  AddonManager.getAddonByID(GM_GUID, function(addon) {
+    gGreasemonkeyVersion = '' + addon.version;
+    aService.broadcastScriptUpdates();
+  });
+  
+  // beam down on updates
+  aService.config.addObserver({notifyEvent: function(script, event, data) {
+    if(["modified", "install", "move", "edit-enabled", "uninstall"].some(function(e) {return e == event;})) {
+      aService.broadcastScriptUpdates();
+    }
+  }});
+  
+  Cu.import("chrome://greasemonkey-modules/content/refererSetter.js", {});
 
   Services.obs.addObserver(aService, 'quit-application', false);
 
@@ -133,6 +152,37 @@ service.prototype.__defineGetter__('config', function() {
   return this._config;
 });
 
+service.prototype.scriptUpdateData = function() {
+  var ipcScripts = this.config.scripts.map(function(script) {
+    return new IPCScript(script, gGreasemonkeyVersion);        
+  });
+  
+  var excludes = this.config._globalExcludes;
+  
+  var data = { scripts: ipcScripts, globalExcludes: excludes};
+  
+  return data;
+}
+
+service.prototype.broadcastScriptUpdates = function() {
+  
+  var data = this.scriptUpdateData();
+  
+  var ppmm = Cc["@mozilla.org/parentprocessmessagemanager;1"]
+    .getService(Ci.nsIMessageListenerManager);
+  
+  
+  // check if initialProcessData is supported
+  // child will use sync message if not
+  if(ppmm.initialProcessData) {
+    // for new processes
+    ppmm.initialProcessData["greasemonkey:scripts-update"] = data;
+  }
+  
+  // for existing ones
+  ppmm.broadcastAsyncMessage("greasemonkey:scripts-update", data);
+}
+
 service.prototype.closeAllScriptValStores = function() {
   for (var scriptId in this.scriptValStores) {
     var scriptValStore = this.scriptValStores[scriptId];
@@ -140,33 +190,16 @@ service.prototype.closeAllScriptValStores = function() {
   }
 };
 
-service.prototype.getScriptsForUrl = function(aMessage) {
-  var url = aMessage.data.url;
-  var when = aMessage.data.when;
-  var windowId = aMessage.data.windowId;
-  var browser = aMessage.target;
+service.prototype.scriptRefresh = function(url, windowId, browser) {
 
   if (!GM_util.getEnabled() || !url) return [];
   if (!GM_util.isGreasemonkeyable(url)) return [];
 
   if (GM_prefRoot.getValue('enableScriptRefreshing')) {
-    this.config.updateModifiedScripts(when, url, windowId, browser);
+    this.config.updateModifiedScripts("document-start", url, windowId, browser);
+    this.config.updateModifiedScripts("document-end", url, windowId, browser);
   }
 
-  var scripts = this.config.getMatchingScripts(function(script) {
-    try {
-      return GM_util.scriptMatchesUrlAndRuns(script, url, when);
-    } catch (e) {
-      GM_util.logError(e, false, e.fileName, e.lineNumber);
-      // See #1692; Prevent failures like that from being so severe.
-      return false;
-    }
-  }).map(function(script) {
-    // Make the script serializable so it can be sent to the frame script.
-    return new IPCScript(script, gGreasemonkeyVersion);
-  });
-
-  return scripts;
 };
 
 service.prototype.getScriptsForUuid = function(aMessage) {

--- a/content/framescript.js
+++ b/content/framescript.js
@@ -128,16 +128,9 @@ function loadFailedScript(aMessage) {
 function runScripts(aRunWhen, aContentWin) {
   var url = urlForWin(aContentWin);
   if (!GM_util.isGreasemonkeyable(url)) return;
+  
+  var scripts = IPCScript.scriptsForUrl(url, aRunWhen, GM_util.windowId(aContentWin, 'outer'));
 
-  var response = sendSyncMessage(
-    'greasemonkey:scripts-for-url', {
-      'url': url,
-      'when': aRunWhen,
-      'windowId': GM_util.windowId(aContentWin, 'outer'),
-    });
-  if (!response || !response[0]) return;
-
-  var scripts = response[0].map(createScriptFromObject);
   injectScripts(scripts, aContentWin);
 }
 

--- a/modules/abstractScript.js
+++ b/modules/abstractScript.js
@@ -1,0 +1,54 @@
+'use strict';
+
+const EXPORTED_SYMBOLS = ['AbstractScript'];
+
+const gAboutBlankRegexp = /^about:blank/;
+
+const Cu = Components.utils;
+
+Cu.import('chrome://greasemonkey-modules/content/third-party/convert2RegExp.js');
+Cu.import('chrome://greasemonkey-modules/content/third-party/MatchPattern.js');
+Cu.import('chrome://greasemonkey-modules/content/util.js');
+
+function AbstractScript() {
+
+}
+
+Object.defineProperty(AbstractScript.prototype, "globalExcludes", {
+  get: function() {
+    return [];
+  },
+  configurable: true
+});
+
+AbstractScript.prototype.matchesURL = function(url) {
+  var uri = GM_util.uriFromUrl(url);
+
+  function testClude(glob) {
+    // Do not run in about:blank unless _specifically_ requested. See #1298
+    if (gAboutBlankRegexp.test(url) && !gAboutBlankRegexp.test(glob)) {
+      return false;
+    }
+
+    return GM_convert2RegExp(glob, uri).test(url);
+  }
+  function testMatch(matchPattern) {
+    if ('string' == typeof matchPattern)
+      matchPattern = new MatchPattern(matchPattern);
+    return matchPattern.doMatch(url);
+  }
+
+  // Flat deny if URL is not greaseable, or matches global excludes.
+  if (!GM_util.isGreasemonkeyable(url)) return false;
+
+  if (this.globalExcludes.some(testClude)) return false;
+
+  // Allow based on user cludes.
+  if (this.userExcludes.some(testClude)) return false;
+  if (this.userIncludes.some(testClude) || this.userMatches.some(testMatch))
+    return true;
+
+  // Finally allow based on script cludes and matches.
+  if (this.excludes.some(testClude)) return false;
+  return (this.includes.some(testClude) || this.matches.some(testMatch));
+};

--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -1,6 +1,5 @@
 var EXPORTED_SYMBOLS = ['IPCScript'];
 
-Components.utils.import("chrome://greasemonkey-modules/content/extractMeta.js");
 Components.utils.import("chrome://greasemonkey-modules/content/util.js");
 
 function IPCScript(aScript, addonVersion) {
@@ -17,15 +16,13 @@ function IPCScript(aScript, addonVersion) {
   this.namespace = aScript.namespace;
   this.noframes = aScript.noframes;
   this.runAt = aScript.runAt;
-  this.textContent = aScript.textContent;
   this.uuid = aScript.uuid;
   this.version = aScript.version;
   this.willUpdate = aScript.isRemoteUpdateAllowed();
 
   this.requires = aScript.requires.map(function(req) {
     return {
-      'fileURL': req.fileURL,
-      'textContent': req.textContent
+      'fileURL': req.fileURL
     };
   });
 
@@ -33,20 +30,10 @@ function IPCScript(aScript, addonVersion) {
     return {
       'name': res.name,
       'mimetype': res.mimetype,
-      'textContent': res.textContent,
       'url': GM_util.getUriFromFile(res.file).spec
     };
   });
 };
-
-IPCScript.prototype.__defineGetter__('metaStr',
-function IPCScript_getMetaStr() {
-  if (!this._metaStr) {
-    this._metaStr = extractMeta(this.textContent);
-  }
-
-  return this._metaStr;
-});
 
 IPCScript.prototype.info = function() {
   var resources = {};
@@ -60,8 +47,6 @@ IPCScript.prototype.info = function() {
   return {
     'uuid': this.uuid,
     'version': this.addonVersion,
-    'scriptMetaStr': this.metaStr,
-    'scriptSource': this.textContent,
     'scriptWillUpdate': this.willUpdate,
     'script': {
       'description': this.description,

--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -1,17 +1,33 @@
 var EXPORTED_SYMBOLS = ['IPCScript'];
 
 Components.utils.import("chrome://greasemonkey-modules/content/util.js");
+Components.utils.import('chrome://greasemonkey-modules/content/abstractScript.js');
+
+
+// IPCScript class
+
 
 function IPCScript(aScript, addonVersion) {
   this.addonVersion = addonVersion;
+  this.enabled = aScript.enabled;
+  this.needsUninstall = aScript.needsUninstall;
+  this.pendingExec = {};
+  this.pendingExec.length = aScript.pendingExec.length || 0
   this.description = aScript.description;
   this.excludes = aScript.excludes;
+  this.userExcludes = aScript.userExcludes;
   this.fileURL = aScript.fileURL;
   this.grants = aScript.grants;
   this.id = aScript.id;
   this.includes = aScript.includes;
+  this.userIncludes = aScript.userIncludes;
   this.localized = aScript.localized;
-  this.matches = aScript.matches.map(function(m) { return m.pattern; });
+  this.matches = aScript.matches.map(function(m) {
+    return m.pattern;
+  });
+  this.userMatches = aScript.userMatches.map(function(m) {
+    return m.pattern;
+  });
   this.name = aScript.name;
   this.namespace = aScript.namespace;
   this.noframes = aScript.noframes;
@@ -34,6 +50,70 @@ function IPCScript(aScript, addonVersion) {
     };
   });
 };
+
+//inheritance magic
+IPCScript.prototype = Object.create(AbstractScript.prototype, {
+  constructor: {
+    value: IPCScript 
+  }
+});
+
+
+// initialize module-scoped stuff, after prototype override
+
+var scripts = [];
+
+const cpmm = Components.classes["@mozilla.org/childprocessmessagemanager;1"]
+    .getService(Components.interfaces.nsISyncMessageSender);
+
+function objectToScript(obj) {
+  var script = Object.create(IPCScript.prototype);
+  Object.keys(obj).forEach(function(k) {
+    script[k] = obj[k];
+  });
+  Object.freeze(script);
+  return script;
+}
+
+function updateData(data) {
+  if (!data) return;
+  var newScripts = data.scripts.map(objectToScript);
+  Object.freeze(newScripts);
+  scripts = newScripts;
+  IPCScript.prototype.globalExcludes = data.globalExcludes;
+}
+
+if (cpmm.initialProcessData) {
+  updateData(cpmm.initialProcessData["greasemonkey:scripts-update"]);
+} else {
+  // support FF < 41
+  var results = cpmm.sendSyncMessage("greasemonkey:scripts-update");
+  updateData(results[0]);
+}
+
+cpmm.addMessageListener("greasemonkey:scripts-update", function(message) {
+  updateData(message.data);
+});
+
+
+
+// static method
+
+IPCScript.scriptsForUrl = function(url, when, windowId) {
+    return scripts.filter(function(script) {
+      try {
+        return GM_util.scriptMatchesUrlAndRuns(script, url, when);
+      } catch (e) {
+        console.log(e);
+        GM_util.logError(e, false, e.fileName, e.lineNumber);
+        // See #1692; Prevent failures like that from being so severe.
+        return false;
+      }
+   });
+}
+
+// instance methods
+
 
 IPCScript.prototype.info = function() {
   var resources = {};

--- a/modules/miscapis.js
+++ b/modules/miscapis.js
@@ -24,8 +24,13 @@ GM_Resources.prototype.getResourceURL = function(aScript, name) {
   return ['greasemonkey-script:', aScript.uuid, '/', name].join('');
 };
 
+
 GM_Resources.prototype.getResourceText = function(name) {
-  return this._getDep(name).textContent;
+  var dep = this._getDep(name)
+  if(dep.textContent !== undefined)
+    return dep.textContent;
+  // lazy resources in IPC scripts
+  return GM_util.fileXHR(dep.url, "text/plain");
 };
 
 GM_Resources.prototype._getDep = function(name) {

--- a/modules/refererSetter.js
+++ b/modules/refererSetter.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const EXPORTED_SYMBOLS = [];
+
+Components.utils.import("resource://gre/modules/Services.jsm");
+
+const observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+
+Services.obs.addObserver({
+  observe: function(subject, topic, data) {
+    if(!(subject instanceof Components.interfaces.nsIHttpChannel))
+      return;
+    if(!(subject instanceof Components.interfaces.nsIPropertyBag))
+      return;
+
+    var channel = subject; // instanceof -> automatic QI
+    var referer;
+    
+    try{
+      referer = channel.getProperty("greasemonkey:referer-override");      
+    } catch(ex) {
+      // property not found
+      return;
+    }
+    
+    channel.setRequestHeader("Referer", referer, false);
+  }
+}, "http-on-modify-request", false);

--- a/modules/refererSetter.js
+++ b/modules/refererSetter.js
@@ -3,26 +3,54 @@
 const EXPORTED_SYMBOLS = [];
 
 Components.utils.import("resource://gre/modules/Services.jsm");
+Components.utils.import("chrome://greasemonkey-modules/content/util.js");
+Components.utils.import("chrome://greasemonkey-modules/content/prefmanager.js");
 
-const observerService = Components.classes["@mozilla.org/observer-service;1"].getService(Components.interfaces.nsIObserverService);
+const types = Components.interfaces.nsIContentPolicy
+
+function overrideReferer(subject) {
+  if (!(subject instanceof Components.interfaces.nsIHttpChannel)) return;
+  if (!(subject instanceof Components.interfaces.nsIPropertyBag)) return;
+
+  var channel = subject; // instanceof -> automatic QI
+  var referer;
+
+  try {
+    referer = channel.getProperty("greasemonkey:referer-override");
+  } catch (ex) {
+    // property not found
+    return;
+  }
+
+  channel.setRequestHeader("Referer", referer, false);
+
+}
+
+function checkScriptRefresh(channel) {
+  if (!channel.loadInfo) return;
+
+  var type = channel.loadInfo.contentPolicyType;
+  if (type != types.TYPE_DOCUMENT && type != types.TYPE_SUBDOCUMENT) return;
+
+  // forward compatibility: https://bugzilla.mozilla.org/show_bug.cgi?id=1124477
+  var browser = channel.loadInfo.topFrameElement;
+
+  if (!browser && channel.notificationCallbacks) {
+    // current API: https://bugzilla.mozilla.org/show_bug.cgi?id=1123008#c7
+    var loadCtx = channel.notificationCallbacks.QueryInterface(
+        Components.interfaces.nsIInterfaceRequestor).getInterface(
+        Components.interfaces.nsILoadContext);
+    browser = loadCtx.topFrameElement;
+  }
+
+  var windowId = channel.loadInfo.innerWindowID;
+
+  GM_util.getService().scriptRefresh(channel.URI.spec, windowId, browser);
+}
 
 Services.obs.addObserver({
   observe: function(subject, topic, data) {
-    if(!(subject instanceof Components.interfaces.nsIHttpChannel))
-      return;
-    if(!(subject instanceof Components.interfaces.nsIPropertyBag))
-      return;
-
-    var channel = subject; // instanceof -> automatic QI
-    var referer;
-    
-    try{
-      referer = channel.getProperty("greasemonkey:referer-override");      
-    } catch(ex) {
-      // property not found
-      return;
-    }
-    
-    channel.setRequestHeader("Referer", referer, false);
+    overrideReferer(subject);
+    checkScriptRefresh(subject);
   }
 }, "http-on-modify-request", false);

--- a/modules/sandbox.js
+++ b/modules/sandbox.js
@@ -11,12 +11,15 @@ Cu.import("chrome://greasemonkey-modules/content/miscapis.js");
 Cu.import("chrome://greasemonkey-modules/content/storageFront.js");
 Cu.import("chrome://greasemonkey-modules/content/util.js");
 Cu.import("chrome://greasemonkey-modules/content/xmlhttprequester.js");
+Cu.import("chrome://greasemonkey-modules/content/extractMeta.js");
 
 var gStringBundle = Cc["@mozilla.org/intl/stringbundle;1"]
     .getService(Ci.nsIStringBundleService)
     .createBundle("chrome://greasemonkey/locale/greasemonkey.properties");
 var gInvalidAccesskeyErrorStr = gStringBundle
     .GetStringFromName('error.menu-invalid-accesskey');
+var subLoader = Components.classes["@mozilla.org/moz/jssubscript-loader;1"]
+    .getService(Components.interfaces.mozIJSSubScriptLoader);
 
 // Only a particular set of strings are allowed.  See: http://goo.gl/ex2LJ
 var gMaxJSVersion = "ECMAv5";
@@ -35,9 +38,8 @@ function createSandbox(aScript, aContentWin, aUrl, aFrameScope) {
           'wantXrays': false,
         });
     // GM_info is always provided.
-    // TODO: lazy getter? XPCOMUtils.defineLazyGetter
-    Components.utils.evalInSandbox(
-        'const GM_info = ' + uneval(aScript.info()), contentSandbox);
+    injectGMInfo(aScript, contentSandbox);
+
     // Alias unsafeWindow for compatibility.
     Components.utils.evalInSandbox(
         'const unsafeWindow = window;', contentSandbox);
@@ -121,19 +123,69 @@ function createSandbox(aScript, aContentWin, aUrl, aFrameScope) {
         'contentStartRequest');
   }
 
-  // TODO: lazy getter?
-  Components.utils.evalInSandbox(
-      'const GM_info = ' + uneval(aScript.info()), sandbox);
+  injectGMInfo(aScript, sandbox);
 
   return sandbox;
 }
 
 
+
+function injectGMInfo(aScript, sandbox) {
+  var rawInfo = aScript.info();
+  var scriptURL = aScript.fileURL;
+
+  // TODO: also delay top level clone via lazy getter? XPCOMUtils.defineLazyGetter
+  sandbox.GM_info = Cu.cloneInto(rawInfo, sandbox);
+  
+  var waivedInfo = Components.utils.waiveXrays(sandbox.GM_info);
+  
+  var fileCache = new Map();
+  
+
+  function getScriptSource() {
+    var content = fileCache.get("scriptSource");
+    if (content === undefined) {
+      content = GM_util.fileXHR(scriptURL, "application/javascript");
+      fileCache.set("scriptSource", content);
+    }
+    return content;
+  }
+
+  function getMeta() {
+    var meta = fileCache.get("meta");
+    if (meta === undefined) {
+      meta = extractMeta(getScriptSource());
+      fileCache.set("meta", meta);
+    }
+    return meta;
+  }
+
+  // lazy getters for heavyweight strings that aren't sent down through IPC
+  Object.defineProperty(waivedInfo, "scriptSource", {
+    get: Cu.exportFunction(getScriptSource, sandbox)
+  });
+
+  // meta depends on content, so we need a lazy one here too
+  Object.defineProperty(waivedInfo, 'scriptMetaStr', {
+    get: Cu.exportFunction(getMeta, sandbox)
+  });
+
+}
+
+function uriToString(uri) {
+  var channel = NetUtil.newChannel({ uri: NetUtil.newURI(uri, "UTF-8"), loadUsingSystemPrincipal: true});
+  var stream = channel.open();
+
+  var count = stream.available();
+  var data = NetUtil.readInputStreamToString(stream, count, { charset : "utf-8" });
+  return data;
+}
+
 function runScriptInSandbox(script, sandbox) {
   // Eval the code, with anonymous wrappers when/if appropriate.
-  function evalWithWrapper(code, fileName) {
+  function evalWithWrapper(uri) {
     try {
-      Components.utils.evalInSandbox(code, sandbox, gMaxJSVersion, fileName, 1);
+    	subLoader.loadSubScript(uri, sandbox, "UTF-8");
     } catch (e) {
       if ("return not in function" == e.message) {
         // See #1592; we never anon wrap anymore, unless forced to by a return
@@ -144,8 +196,11 @@ function runScriptInSandbox(script, sandbox) {
             fileName,
             e.lineNumber
             );
+        
+        var code = GM_util.fileXHR(uri, "application/javascript");
+        
         Components.utils.evalInSandbox(
-            '(function(){ '+code+'\n})()', sandbox, gMaxJSVersion, fileName, 1);
+            '(function(){ '+code+'\n})()', sandbox, gMaxJSVersion, uri, 1);
       } else {
         // Otherwise raise.
         throw e;
@@ -154,12 +209,12 @@ function runScriptInSandbox(script, sandbox) {
   }
 
   // Eval the code, with a try/catch to report errors cleanly.
-  function evalWithCatch(code, fileName) {
+  function evalWithCatch(uri) {
     try {
-      evalWithWrapper(code, fileName);
+      evalWithWrapper(uri);
     } catch (e) {
       // Log it properly.
-      GM_util.logError(e, false, fileName, e.lineNumber);
+      GM_util.logError(e, false, e.fileName, e.lineNumber);
       // Stop the script, in the case of requires, as if it was one big script.
       return false;
     }
@@ -167,9 +222,9 @@ function runScriptInSandbox(script, sandbox) {
   }
 
   for (var i = 0, require = null; require = script.requires[i]; i++) {
-    if (!evalWithCatch(require.textContent, require.fileURL)) {
+    if (!evalWithCatch(require.fileURL)) {
       return;
     }
   }
-  evalWithCatch(script.textContent, script.fileURL);
+  evalWithCatch(script.fileURL);
 }

--- a/modules/util.js
+++ b/modules/util.js
@@ -28,6 +28,7 @@ XPCOMUtils.defineLazyModuleGetter(GM_util, 'channelFromUri', 'chrome://greasemon
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'compareFirefoxVersion', 'chrome://greasemonkey-modules/content/util/compareFirefoxVersion.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'emptyEl', 'chrome://greasemonkey-modules/content/util/emptyEl.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'enqueueRemoveFile', 'chrome://greasemonkey-modules/content/util/enqueueRemoveFile.js');
+XPCOMUtils.defineLazyModuleGetter(GM_util, 'fileXHR', 'chrome://greasemonkey-modules/content/util/fileXHR.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'findMessageManager', 'chrome://greasemonkey-modules/content/util/findMessageManager.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'getBestLocaleMatch', 'chrome://greasemonkey-modules/content/util/getBestLocaleMatch.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'getBinaryContents', 'chrome://greasemonkey-modules/content/util/getBinaryContents.js');

--- a/modules/util/fileXHR.js
+++ b/modules/util/fileXHR.js
@@ -1,0 +1,15 @@
+'use strict';
+
+var EXPORTED_SYMBOLS = ['fileXHR'];
+
+Components.utils.importGlobalProperties(["XMLHttpRequest"]);
+
+// sync XHR. it's just meant to fetch file:// uris that aren't otherwise accessible in content
+// don't use it in the parent process or for web URLs
+function fileXHR(uri, mimetype) {
+  var xhr = new XMLHttpRequest();
+  xhr.open("open", uri, false);
+  xhr.overrideMimeType(mimetype);
+  xhr.send(null);  
+  return xhr.responseText;
+}

--- a/modules/xmlhttprequester.js
+++ b/modules/xmlhttprequester.js
@@ -192,27 +192,13 @@ function(safeUrl, details, req) {
 GM_xmlhttpRequester.prototype.setupReferer =
 function(details, req) {
   if (!details.headers || !details.headers.Referer) return;
-
-  var observerService = Components.classes["@mozilla.org/observer-service;1"]
-      .getService(Components.interfaces.nsIObserverService);
-  var requestObserver = {};
-  requestObserver.observe = function(subject, topic, data) {
-      observerService.removeObserver(requestObserver, "http-on-modify-request");
-
-      var channel = subject.QueryInterface(Components.interfaces.nsIChannel);
-      if (channel == req.channel) {
-        dump('setting referer ' + details.headers.Referer + '\n');
-        var httpChannel = subject.QueryInterface(
-            Components.interfaces.nsIHttpChannel);
-        httpChannel.setRequestHeader("Referer", details.headers.Referer, false);
-      }
-    };
-
-  // This fails under e10s.  Ignore for now (Mar 13, 2015).
-  // TODO: Make it work!
-  try {
-    observerService.addObserver(requestObserver, "http-on-modify-request", false);
-  } catch (e) { }
+  
+  var channel = req.channel;
+  
+  if(!(channel  instanceof Components.interfaces.nsIWritablePropertyBag))
+    return;
+  
+  channel.setProperty("greasemonkey:referer-override", details.headers.Referer);  
 };
 
 // arranges for the specified 'event' on xmlhttprequest 'req' to call the


### PR DESCRIPTION
This removes the sync `greasemonkey:scripts-for-url` message from the framescript.

builds on work from PR #2243 and #2255