### PR TITLE
GM 3.3beta2+: Fix synchronization of commands between popups

### DIFF
--- a/content/menucommander.js
+++ b/content/menucommander.js
@@ -43,11 +43,13 @@ GM_MenuCommander.createMenuItem = function(command) {
 GM_MenuCommander.messageMenuCommandResponse = function(aMessage) {
   if (aMessage.data.cookie != GM_MenuCommander.cookieShowing) return;
 
-  GM_MenuCommander.popup.parentNode.disabled = false;
   for (i in aMessage.data.commands) {
     var command = aMessage.data.commands[i];
     var menuItem = GM_MenuCommander.createMenuItem(command);
     GM_MenuCommander.popup.appendChild(menuItem);
+  }
+  if (GM_MenuCommander.popup.firstChild) {
+    GM_MenuCommander.popup.parentNode.disabled = false;
   }
 };
 
@@ -59,10 +61,8 @@ GM_MenuCommander.onPopupHiding = function() {
 
 
 GM_MenuCommander.onPopupShowing = function(aEvent) {
-  if (!GM_MenuCommander.popup) {
-    GM_MenuCommander.popup = aEvent.target.querySelector(
-        'menupopup.greasemonkey-user-script-commands-popup');
-  }
+  GM_MenuCommander.popup = aEvent.target.querySelector(
+      'menupopup.greasemonkey-user-script-commands-popup');
 
   GM_MenuCommander.messageCookie++;
   GM_MenuCommander.cookieShowing = GM_MenuCommander.messageCookie;


### PR DESCRIPTION
The suggestion (for example).

Fix synchronization of commands between popups (and after a page refresh F5 - if the number of commands change: 0, >0).

1st step:
![1](https://cloud.githubusercontent.com/assets/2373486/9833514/a9b166b4-5999-11e5-8946-007706c8d910.png)

2st step:
![2](https://cloud.githubusercontent.com/assets/2373486/9833515/ae0b6b60-5999-11e5-8ccf-161cfb69ad9a.png)
