### PR TITLE
Allow .cmd as editor executable. Fixes #2271 

### DIFF
--- a/modules/util/setEditor.js
+++ b/modules/util/setEditor.js
@@ -1,5 +1,6 @@
 Components.utils.import('chrome://greasemonkey-modules/content/prefmanager.js');
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
+Components.utils.import("resource://gre/modules/Services.jsm");
 
 var EXPORTED_SYMBOLS = ['setEditor'];
 
@@ -27,8 +28,11 @@ function setEditor(aScratchpad) {
     filePicker.init(
         GM_util.getBrowserWindow(), EDITOR_PROMPT, nsIFilePicker.modeOpen);
     filePicker.appendFilters(nsIFilePicker.filterApps);
-    filePicker.appendFilter("*.cmd", "*.cmd");
-
+    if (Services.appShell.hiddenDOMWindow.navigator.platform
+        .indexOf("Win") != -1) {
+      filePicker.appendFilter("*.cmd", "*.cmd");
+    }
+    
     var editor = GM_util.getEditor();
     if (editor) {
       filePicker.defaultString = editor.leafName;

--- a/modules/util/setEditor.js
+++ b/modules/util/setEditor.js
@@ -27,6 +27,7 @@ function setEditor(aScratchpad) {
     filePicker.init(
         GM_util.getBrowserWindow(), EDITOR_PROMPT, nsIFilePicker.modeOpen);
     filePicker.appendFilters(nsIFilePicker.filterApps);
+    filePicker.appendFilter("*.cmd", "*.cmd");
 
     var editor = GM_util.getEditor();
     if (editor) {


### PR DESCRIPTION
Fixes: https://github.com/greasemonkey/greasemonkey/issues/2271

![2015-09-13 10_51_44-comparing master issues_ 2271-allow-cmd jerone_greasemonkey](https://cloud.githubusercontent.com/assets/55841/9835990/7917d404-5a05-11e5-9c84-af1b13659c3a.png)
