### PR TITLE
GM 3.4.1: If just one script is installed (and updated)

### DIFF
--- a/content/addons4-overlay.js
+++ b/content/addons4-overlay.js
@@ -76,11 +76,9 @@ var observer = {
           // remove this item from the UI.
           gListView.removeItem(addon);
         }
-        setEmptyWarningVisible();
         break;
       case 'install':
         gListView.addItem(addon);
-        setEmptyWarningVisible();
         break;
       case 'edit-enabled':
         var item = gListView.getListItemForID(addon.id);
@@ -105,6 +103,7 @@ var observer = {
         oldItem.parentNode.replaceChild(item, oldItem);
         break;
     }
+    setEmptyWarningVisible();
   }
 };
 


### PR DESCRIPTION
Ad https://github.com/greasemonkey/greasemonkey/issues/2274#issuecomment-140902678
The suggestion (for example).

__I think it has to do with it being version 3.4.1, but I sometimes write too complicated (or too simple) :-) Maybe both at once :-)__

#### Steps to reproduce:
1) I trying make a new profile of Firefox
2) Installing Greasemonkey (v3.4.1)
3) Installation of this script (e.g.):
``` javascript
// ==UserScript==
// @name        test
// @include     *
// @version     1.0
// @grant       none
// @downloadURL http://localhost/test.user.js
// ==/UserScript==
alert("hi");
```
4) I change a script (file) on the "server" (@version 1.0 => @version 1.1), saving
5) Firefox => Add-ons Manager => Right-click on the script and click "Find Updates"
![1](https://cloud.githubusercontent.com/assets/2373486/9939244/96e7dbc0-5d69-11e5-8d75-c399baca90a8.png)
6a) GM 3.4.1 - the result:
![2](https://cloud.githubusercontent.com/assets/2373486/9939257/a2d3bdf0-5d69-11e5-82db-f35f8285d712.png)
6b) GM 3.4beta3- - the result:
![3](https://cloud.githubusercontent.com/assets/2373486/9939263/b1211e02-5d69-11e5-8ebd-522a2a1a39da.png)
