### PR TITLE
Update greasemonkey.dtd

### DIFF
--- a/locale/fr/greasemonkey.dtd
+++ b/locale/fr/greasemonkey.dtd
@@ -26,7 +26,7 @@
 <!ENTITY install.warning2 "Installez uniquement des scripts à partir de sources auxquelles vous faites confiance.">
 <!ENTITY install.showscriptsource "Afficher la source du Script">
 <!ENTITY install.installbutton "Installer">
-<!ENTITY install.downloadError "Télécharger l'erreur">
+<!ENTITY install.downloadError "Erreur de téléchargement">
 <!ENTITY loading "Téléchargement...">
 <!ENTITY newscript.name "Nom">
 <!ENTITY newscript.namespace "Espace de nom">


### PR DESCRIPTION
A message I came across for the first time afters years of using Greasemonkey.
« Télécharger l'erreur » means “download the error” and I bet this is not what the user wants to do :P