### PR TITLE
Minor fix - throws an error in the Browser Console

### DIFF
--- a/content/install.js
+++ b/content/install.js
@@ -86,7 +86,7 @@ function onProgress(aRemoteScript, aEventType, aData) {
 
     document.getElementById('loading').style.display = 'none';
     if (gRemoteScript.errorMessage) {
-      document.documentElement.getButton('extra1').disabled = true;
+      gShowScriptButton.disabled = true;
       document.getElementById('dialogContentBox').style.display = 'none';
       document.getElementById('errorContentBox').style.display = '-moz-box';
       document.getElementById('errorMessage')

--- a/modules/remoteScript.js
+++ b/modules/remoteScript.js
@@ -265,7 +265,11 @@ RemoteScript.prototype.cancel = function() {
 
 /** Clean up all temporary files, stop all actions. */
 RemoteScript.prototype.cleanup = function(aErrorMessage) {
-  this.errorMessage = aErrorMessage || null;
+  this.errorMessage = null;
+  // See #2327
+  if (aErrorMessage && ("object" != typeof aErrorMessage)) {
+    this.errorMessage = aErrorMessage;
+  }
   this.done = true;
 
   this._channels.forEach(function(aChannel) {


### PR DESCRIPTION
Steps to reproduce:
- I have a script with @resource (i.e. https://gist.github.com/arantius/1157543#file-api-tester-user-js)
- During installation, press “Show Script Source”
- Close view tab
- Throws an error in the Browser Console
![error](https://cloud.githubusercontent.com/assets/2373486/10991220/e48dd3e8-845b-11e5-9dd7-ae46e44c51a8.png)

See https://github.com/greasemonkey/greasemonkey/blob/3.5/modules/remoteScript.js#L469:
https://github.com/greasemonkey/greasemonkey/blob/3.5/modules/remoteScript.js#L267
(aErrorMessage = [object UIEvent]) 
