### PR TITLE
Always use IPC scripts for greasemonkey-script: scheme

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -65,9 +65,7 @@ function startup(aService) {
 
   var parentMessageManager = Cc["@mozilla.org/parentprocessmessagemanager;1"]
       .getService(Ci.nsIMessageListenerManager);
-  parentMessageManager.addMessageListener(
-      'greasemonkey:scripts-for-uuid',
-      aService.getScriptsForUuid.bind(aService));
+
   parentMessageManager.addMessageListener("greasemonkey:scripts-update", function(message) {
     return aService.scriptUpdateData();
   });
@@ -189,17 +187,6 @@ service.prototype.scriptRefresh = function(url, windowId, browser) {
     this.config.updateModifiedScripts("document-end", url, windowId, browser);
     this.config.updateModifiedScripts("document-idle", url, windowId, browser);
   }
-};
-
-service.prototype.getScriptsForUuid = function(aMessage) {
-  var uuid = aMessage.data.uuid;
-  var scripts = this.config.getMatchingScripts(
-      function(script) { return script.uuid == uuid; }
-  ).map(function(script) {
-    // Make the script serializable so it can be sent to the frame script.
-    return new IPCScript(script, gGreasemonkeyVersion);
-  });
-  return scripts;
 };
 
 service.prototype.getStoreByScriptId = function(aScriptId) {

--- a/modules/ipcscript.js
+++ b/modules/ipcscript.js
@@ -121,6 +121,11 @@ function objectToScript(obj) {
   return script;
 }
 
+IPCScript.getByUuid = function (id) {
+  return scripts.find(function(e) {
+    return e.uuid == id
+  })  
+}
 
 function updateData(data) {
   if (!data) return;

--- a/modules/scriptProtocol.js
+++ b/modules/scriptProtocol.js
@@ -3,6 +3,7 @@ var EXPORTED_SYMBOLS = ['initScriptProtocol'];
 Components.utils.import("resource://gre/modules/XPCOMUtils.jsm");
 Components.utils.import("resource://gre/modules/Services.jsm");
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
+Components.utils.import("chrome://greasemonkey-modules/content/ipcscript.js");;
 
 var Cc = Components.classes;
 var Ci = Components.interfaces;
@@ -112,40 +113,14 @@ var ScriptProtocol = {
     // Incomplete URI, send a 404.
     if (!m) return dummy;
 
-    var script = null;
-    // If we're serving (e.g.) a favicon image, this request can be coming
-    // from the parent process!
-    var runtime = Cc["@mozilla.org/xre/app-info;1"]
-        .getService(Ci.nsIXULRuntime);
-    if (runtime.processType == Ci.nsIXULRuntime.PROCESS_TYPE_DEFAULT) {
-      var scripts = GM_util.getService().config.getMatchingScripts(
-          function(script) { return script.uuid == m[1]; }
-      );
-      script = scripts && scripts.length && scripts[0];
-    } else {
-      var mm = Cc["@mozilla.org/childprocessmessagemanager;1"]
-          .getService(Ci.nsISyncMessageSender);
-      var response = mm.sendSyncMessage(
-          'greasemonkey:scripts-for-uuid', {'uuid': m[1]});
-      // We expect exactly one response, listing exactly one script.
-      if (response.length != 1) return dummy;
-      if (response[0].length != 1) return dummy;
-      script = response[0][0];
-    }
-
+    var script = IPCScript.getByUuid(m[1]);
+    
     // Fail fast if we couldn't find the script.
     if (!script) return dummy;
 
     for (var i = 0, resource = null; resource = script.resources[i]; i++) {
       if (resource.name == m[2]) {
-        var uri = null;
-        if (resource.url) {
-          // In child scope, IPCScript gives us the URL to the file.
-          uri = GM_util.uriFromUrl(resource.url);
-        } else {
-          // In parent scope we have the raw script, with file intact.
-          uri = GM_util.getUriFromFile(resource.file);
-        }
+        var uri = GM_util.uriFromUrl(resource.file_url);
 
         // Get the channel for the file URI, but set its originalURI to the
         // greasemonkey-script: protocol URI, to ensure it can still be loaded


### PR DESCRIPTION
- eliminates different code paths for parent/child
- eliminates a sync messages
- fewer Lines of Code

Tested against test script provided by @daniels1989 in #2326