### PR TITLE
Cannot use an image file that is locally downloaded via @resource, as an icon in a `input` element

### DIFF
--- a/modules/scriptProtocol.js
+++ b/modules/scriptProtocol.js
@@ -139,9 +139,9 @@ var ScriptProtocol = {
     for (var i = 0, resource = null; resource = script.resources[i]; i++) {
       if (resource.name == m[2]) {
         var uri = null;
-        if (resource.url) {
+        if (resource.file_url) {
           // In child scope, IPCScript gives us the URL to the file.
-          uri = GM_util.uriFromUrl(resource.url);
+          uri = GM_util.uriFromUrl(resource.file_url);
         } else {
           // In parent scope we have the raw script, with file intact.
           uri = GM_util.getUriFromFile(resource.file);


### PR DESCRIPTION
Ad #2341

The error in the Browser Console:
![1](https://cloud.githubusercontent.com/assets/2373486/11826770/89a182ae-a387-11e5-873e-171c1c39c82c.png)

Ad https://github.com/greasemonkey/greasemonkey/commit/9dac77c4fc9cb89b31701e41c321f6712055a81c
