### PR TITLE
User-specified include/exclude rules require Firefox restart to take effect

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -91,7 +91,7 @@ function startup(aService) {
 
   // Beam down on updates.
   aService.config.addObserver({notifyEvent: function(script, event, data) {
-    if (["modified", "install", "move", "edit-enabled", "uninstall"]
+    if (["modified", "install", "move", "edit-enabled", "uninstall", "cludes"]
         .some(function(e) {return e == event;})
       ) {
         aService.broadcastScriptUpdates();


### PR DESCRIPTION
Ad #2361
The suggestion (for example).
