### PR TITLE
GM 3.7beta3: Throws an error in the Browser Console (if metadata not found)

### DIFF
--- a/modules/remoteScript.js
+++ b/modules/remoteScript.js
@@ -415,10 +415,12 @@ RemoteScript.prototype.parseScript = function(aSource, aFatal) {
   Components.utils.import('chrome://greasemonkey-modules/content/parseScript.js', scope);
   var script = scope.parse(aSource, this._uri, aFatal);
   if (!script || script.parseErrors.length) {
-    if (aFatal) {
+    if (!aFatal) {
       this.cleanup(
           stringBundle.GetStringFromName('error.parsingScript')
-          + '\n' + script.parseErrors);
+          + '\n' + (script
+              ? script.parseErrors
+              : stringBundle.GetStringFromName("error.unknown")));
     }
     return false;
   }


### PR DESCRIPTION
The user script:
``` javascript
// ==UserScript==
// ==/UserScript==

var something;
```

Throws an error in the Browser Console:
![1](https://cloud.githubusercontent.com/assets/2373486/13173920/9adccef0-d700-11e5-9fcf-aca71e45fd71.png)

The reason is:
1) https://github.com/greasemonkey/greasemonkey/commit/21196c5bc1a34f23df0c1805d1e9c088359a5777
2) The same unfixed bug: https://github.com/greasemonkey/greasemonkey/commit/f5b2de99840791d4d3f0844617a9c2d00d01ca04
