### PR TITLE
Minor fix - the main menu - jumps up a bit

### DIFF
--- a/content/browser.xul
+++ b/content/browser.xul
@@ -104,7 +104,7 @@
 
       <menuseparator />
       <menuseparator class="scripts-top-point" collapsed="true" />
-      <menuseparator class="scripts-sep" />
+      <menuseparator class="scripts-sep" collapsed="true" />
       <menuseparator class="scripts-framed-point" collapsed="true" />
       <menuseparator collapsed="true" />
       <menuitem class="no-scripts" label="&greasemonkey.noscriptshere;" disabled="true" />


### PR DESCRIPTION
Upon getting into Firefox the first time: I click to bring up the main menu the menu jumps up a bit.

If it is true that: "No installed scripts run on this page."...

See also https://github.com/greasemonkey/greasemonkey/pull/2337
