### PR TITLE
Global exclude rules require Firefox restart to take effect

### DIFF
--- a/components/greasemonkey.js
+++ b/components/greasemonkey.js
@@ -72,6 +72,10 @@ function startup(aService) {
         return aService.scriptUpdateData();
       });
   parentMessageManager.addMessageListener(
+      'greasemonkey:broadcast-script-updates', function (message) {
+        return aService.broadcastScriptUpdates();
+      });
+  parentMessageManager.addMessageListener(
       'greasemonkey:script-install', aService.scriptInstall.bind(aService));
   parentMessageManager.addMessageListener(
       'greasemonkey:url-is-temp-file', aService.urlIsTempFile.bind(aService));

--- a/content/options.js
+++ b/content/options.js
@@ -1,6 +1,10 @@
 Components.utils.import('chrome://greasemonkey-modules/content/prefmanager.js');
 Components.utils.import('chrome://greasemonkey-modules/content/util.js');
 
+var cpmm = Components.classes["@mozilla.org/childprocessmessagemanager;1"]
+    .getService(Components.interfaces.nsISyncMessageSender);
+
+
 function GM_loadOptions() {
   document.getElementById('check-sync')
   .checked = GM_prefRoot.getValue('sync.enabled');
@@ -29,4 +33,6 @@ function GM_saveOptions(checkbox) {
       !!document.getElementById('newScript-removeUnused').checked);
   GM_prefRoot.setValue('newScript.template',
       document.getElementById('newScript-template').value);
+  // Changes to global excludes should be active after tab reload.
+  cpmm.sendAsyncMessage("greasemonkey:broadcast-script-updates");
 }


### PR DESCRIPTION
Changes to global excludes should be active after tab reload.

The suggestion (for example).

See also #2361
(the problem is not completely solved)
