### PR TITLE
fix leaks when opening&closing chrome windows

### DIFF
--- a/content/browser.js
+++ b/content/browser.js
@@ -101,6 +101,7 @@ GM_BrowserUI.openInTab = function(aMessage) {
  */
 GM_BrowserUI.chromeUnload = function() {
   GM_prefRoot.unwatch("enabled", GM_BrowserUI.refreshStatus);
+  GM_MenuCommander.unload();
 };
 
 /**

--- a/content/menucommander.js
+++ b/content/menucommander.js
@@ -9,12 +9,17 @@ var GM_MenuCommander = {
 
 
 GM_MenuCommander.initialize = function() {
-  var ppmm = Components
+  this.ppmm = Components
       .classes["@mozilla.org/parentprocessmessagemanager;1"]
       .getService(Components.interfaces.nsIMessageListenerManager);
-  ppmm.addMessageListener('greasemonkey:menu-command-response',
+  this.ppmm.addMessageListener('greasemonkey:menu-command-response',
       GM_MenuCommander.messageMenuCommandResponse);
 };
+
+GM_MenuCommander.unload = function() {
+  this.ppmm.removeMessageListener('greasemonkey:menu-command-response',
+      GM_MenuCommander.messageMenuCommandResponse);
+}
 
 
 GM_MenuCommander.commandClicked = function(aCommand) {

--- a/modules/prefmanager.js
+++ b/modules/prefmanager.js
@@ -17,7 +17,7 @@ function GM_PrefManager(startPoint) {
      .getService(Components.interfaces.nsIPrefService)
      .getBranch(startPoint);
 
-  this.observers = {};
+  this.observers = new Map();
 };
 
 GM_PrefManager.prototype.MIN_INT_32 = -0x80000000;
@@ -133,7 +133,7 @@ GM_PrefManager.prototype.watch = function(prefName, watcher) {
   };
 
   // store the observer in case we need to remove it later
-  this.observers[watcher] = observer;
+  this.observers.set(watcher,observer);
 
   this.pref.QueryInterface(Components.interfaces.nsIPrefBranchInternal)
       .addObserver(prefName, observer, false);
@@ -143,9 +143,11 @@ GM_PrefManager.prototype.watch = function(prefName, watcher) {
  * stop watching
  */
 GM_PrefManager.prototype.unwatch = function(prefName, watcher) {
-  if (this.observers[watcher]) {
+  var obs = this.observers.get(watcher) 
+  if (obs) {
+    this.observers.delete(watcher);
     this.pref.QueryInterface(Components.interfaces.nsIPrefBranchInternal)
-        .removeObserver(prefName, this.observers[watcher]);
+        .removeObserver(prefName, obs);
   }
 };
 


### PR DESCRIPTION
Currently GM leaks top level windows when you Ctrl+N, Ctrl+W (i.e. simply open and close).

This cleans up the dangling references.

