### PR TITLE
GM_xmlhttpRequest() - if an error occurred, error object throws error

### DIFF
--- a/modules/xmlhttprequester.js
+++ b/modules/xmlhttprequester.js
@@ -32,7 +32,8 @@ function GM_xmlhttpRequester(wrappedContentWin, originUrl, sandbox) {
 // text/xml and we can't support that
 GM_xmlhttpRequester.prototype.contentStartRequest = function(details) {
   if (!details) {
-    throw new Error(gStringBundle.GetStringFromName('error.xhrNoDetails'));
+    throw new this.wrappedContentWin.Error(
+        gStringBundle.GetStringFromName('error.xhrNoDetails'));
   }
   try {
     // Validate and parse the (possibly relative) given URL.
@@ -40,7 +41,7 @@ GM_xmlhttpRequester.prototype.contentStartRequest = function(details) {
     var url = uri.spec;
   } catch (e) {
     // A malformed URL won't be parsed properly.
-    throw new Error(
+    throw new this.wrappedContentWin.Error(
         gStringBundle.GetStringFromName('error.invalidUrl')
             .replace('%1', details.url)
         );
@@ -57,7 +58,7 @@ GM_xmlhttpRequester.prototype.contentStartRequest = function(details) {
         GM_util.hitch(this, "chromeStartRequest", url, details, req)();
       break;
     default:
-      throw new Error(
+      throw new this.wrappedContentWin.Error(
           gStringBundle.GetStringFromName('error.disallowedScheme')
               .replace('%1', details.url)
           );


### PR DESCRIPTION
For example:
``` javascript
// ==UserScript==
// @name        GM_xmlhttpRequest() - if an error occurred, error object throws error
// @include     *
// @grant       GM_xmlhttpRequest
// ==/UserScript==

try {
  GM_xmlhttpRequest();
} catch (e) {
  alert(e);
}
```
Firefox throws an errors in the Error Console:
`Permission denied to access property Symbol.toPrimitive`

Last bad: 2016-07-13
Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0
Built from https://hg.mozilla.org/mozilla-central/rev/04821a70c739a00d12e12df651c0989441e22728

First good: 2016-07-14
Mozilla/5.0 (Windows NT 6.1; WOW64; rv:50.0) Gecko/20100101 Firefox/50.0
Built from https://hg.mozilla.org/mozilla-central/rev/08f8a5aacd8308a73f6040fe522be7ba38497561

Pushlog
http://hg.mozilla.org/mozilla-central/pushloghtml?fromchange=04821a70c739a00d12e12df651c0989441e22728&tochange=08f8a5aacd8308a73f6040fe522be7ba38497561

Bug [1284020](https://bugzilla.mozilla.org/show_bug.cgi?id=1284020) is the suspect.
