### PR TITLE
Improve handling of "script install" failures.

### DIFF
--- a/modules/util/showInstallDialog.js
+++ b/modules/util/showInstallDialog.js
@@ -42,7 +42,7 @@ function showInstallDialog(aUrlOrRemoteScript, aBrowser, aRequest) {
     });
   }
 
-  rs.download(function(aSuccess, aType) {
+  rs.download(function(aSuccess, aType, aStatus) {
     if (aRequest && 'script' == aType) {
       if (aSuccess) {
         aRequest.cancel(Components.results.NS_BINDING_ABORTED);
@@ -51,6 +51,8 @@ function showInstallDialog(aUrlOrRemoteScript, aBrowser, aRequest) {
             .notificationCallbacks.getInterface(Ci.nsILoadContext)
             .topFrameElement;
         browser.webNavigation.stop(Ci.nsIWebNavigation.STOP_ALL);
+      } else if (aStatus >= 500) {
+        aRequest.cancel(Components.results.NS_BINDING_FAILED);
       } else {
         aRequest.resume();
       }

--- a/modules/util/showInstallDialog.js
+++ b/modules/util/showInstallDialog.js
@@ -51,7 +51,9 @@ function showInstallDialog(aUrlOrRemoteScript, aBrowser, aRequest) {
             .notificationCallbacks.getInterface(Ci.nsILoadContext)
             .topFrameElement;
         browser.webNavigation.stop(Ci.nsIWebNavigation.STOP_ALL);
-      } else if (aStatus >= 500) {
+      } else if ((aStatus == 429) || (aStatus >= 500)) {
+        // HTTP status code:
+        // client errors (429 "Too Many Requests"), server errors
         aRequest.cancel(Components.results.NS_BINDING_FAILED);
       } else {
         aRequest.resume();


### PR DESCRIPTION
**1)**

Ad:

Revert "Improve handling of "script install" failures.":
https://github.com/greasemonkey/greasemonkey/commit/fb36493151aa9dce6090d13f57b89dec05430cb3

**I used the condition - "if aStatus is greater than or equal to 500 then"...**
**e.g. error code 404 should be returned if a page does not exist (etc.)**
([Added HTTP code 429](https://github.com/greasemonkey/greasemonkey/pull/2415/commits/d30591fd92f4ae09f3b51a03fee99c4c5be9c8c6))

I think this issue should be reopen:
https://github.com/greasemonkey/greasemonkey/issues/2390

**2)**

"Unable to connect" page - Firefox throws an errors in the Browser Console:

```
NS_ERROR_NOT_AVAILABLE: Component returned failure code: 0x80040111 (NS_ERROR_NOT_AVAILABLE)
[nsIChannel.contentType]
remoteScript.js:170
```

One example of a URL is (github.com => githubS.com):
https://githubs.com/anonim1133/wykop-userjs/blob/a86014414395f71e2b9f930cf8ec876374808c24/wykop-zawijas.user.js

---

See also HTTP Auth (https://github.com/greasemonkey/greasemonkey/pull/2430)

---

The suggestion (for example).
**It is necessary to test all options!**

---
## This should be properly tested!
