### PR TITLE
WIP: provide APIs to bypass CSP restrictions

### DIFF
--- a/modules/util/channelFromUri.js
+++ b/modules/util/channelFromUri.js
@@ -11,10 +11,19 @@ var ioService = Cc['@mozilla.org/network/io-service;1']
 
 
 function channelFromUri(aUri) {
+  let loadInfo = null;
+  if(arguments.length > 1)
+    loadInfo = arguments[1];
+  
+  let trigger = loadInfo && loadInfo.triggeringPrincipal; 
+  let sourceDoc = loadInfo && loadInfo.loadingDocument;
+  let requestType = loadInfo && loadInfo.externalContentPolicyType || Ci.nsIContentPolicy.TYPE_OTHER; 
+    
+  
   if (ioService.newChannelFromURI2) {
     return ioService.newChannelFromURI2(
-        aUri, null, Services.scriptSecurityManager.getSystemPrincipal(),
-        null, Ci.nsILoadInfo.SEC_NORMAL, Ci.nsIContentPolicy.TYPE_OTHER);
+        aUri, sourceDoc, Services.scriptSecurityManager.getSystemPrincipal(),
+        trigger , Ci.nsILoadInfo.SEC_NORMAL, requestType);
   } else {
     return ioService.newChannelFromURI(aUri);
   }


### PR DESCRIPTION
Not finished yet. The question is, would you accept the following set of new features?

* `@grant baseDomain`. this would use a subsuming principal for the sandbox, e.g. `mail.google.com` -> `google.com`. The principal could then use the same OriginAttributes (i.e. containers, 1st party siloing etc.) but ignore CSP
* `@grant isolateFetch`. add sandbox specific XHR and `fetch` constructors. They would still respect SOP/CORS but when combined with the baseDomain grant they would not be subject to CSP. I.e. they would be less powerful than GM_XHR but more powerful than the page's XHR.
* `@grant GM_blobURI`. This would allow the user to generate privileged URIs which bypass CSP. 

I.e. it could do something like this without running afoul of img-src CSPs:

```javascript
// ==UserScript==
// @name        gm_blob test
// @namespace   test
// @version     1
// @grant       GM_blobURI
// @grant       baseDomain
// @grant       isolateFetch
// ==/UserScript==

"use strict";

[...document.querySelectorAll("img")].forEach(img => {
  fetch(img.src).then(rsp => {
    return rsp.blob()
  }).then(blob => {
    let [gmuri, revoker] = GM_blobURI(blob)
    img.src = gmuri
  }).catch(err => {
    console.log(err)
  })
})
```