### PR TITLE
Update CONTRIBUTING for issue rule

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,6 @@
-Please read the [Greasemonkey Programming Style Guide][style-guide] and [Contributing To Greasemonkey][contributing-guide] pages before sending in pull requests.
+Please read the [Greasemonkey Programming Style Guide][style-guide] and [Contributing To Greasemonkey][contributing-guide] pages before sending in pull requests. Questions should be asked in [user forum][user-forum] or [Stack Overflow][stack-overflow] instead of issues here.
 
 [style-guide]: http://greasemonkey.github.io/style.html
 [contributing-guide]: http://greasemonkey.github.io/contrib.html
+[user-forum]: https://groups.google.com/forum/#!forum/greasemonkey-users
+[stack-overflow]: http://stackoverflow.com/questions/tagged/greasemonkey


### PR DESCRIPTION
Points user to forum and Stack Overflow for questions, in order to avoid questions like #2449 and #2452.