### PR TITLE
Fix e10s sandbox preventing scripts to load

### DIFF
--- a/modules/miscapis.js
+++ b/modules/miscapis.js
@@ -28,7 +28,7 @@ GM_Resources.prototype.getResourceURL = function(aScript, name) {
 GM_Resources.prototype.getResourceText = function(sandbox, name, responseType) {
   var dep = this._getDep(name);
   if (dep.textContent !== undefined) return dep.textContent;
-  return Cu.cloneInto(GM_util.fileXhr(
+  return Cu.cloneInto(GM_util.loadFile(
       dep.file_url, "text/plain", responseType), sandbox);
 };
 

--- a/modules/sandbox.js
+++ b/modules/sandbox.js
@@ -186,8 +186,9 @@ function injectGMInfo(aScript, sandbox, aContentWin) {
 function runScriptInSandbox(script, sandbox) {
   // Eval the code, with anonymous wrappers when/if appropriate.
   function evalWithWrapper(url) {
+    const code = GM_util.loadFile(url, "text/plain,charset=utf-8");
     try {
-      subLoader.loadSubScript(url, sandbox, "UTF-8");
+      Cu.evalInSandbox(code, sandbox, "latest", url);
     } catch (e) {
       if ("return not in function" == e.message) {
         // See #1592; we never anon wrap anymore, unless forced to by a return
@@ -199,13 +200,12 @@ function runScriptInSandbox(script, sandbox) {
             e.lineNumber
             );
 
-        var code = GM_util.fileXhr(url, "application/javascript");
         Components.utils.evalInSandbox(
-            '(function(){ '+code+'\n})()', sandbox, gMaxJSVersion, url, 1);
-      } else {
-        // Otherwise raise.
-        throw e;
+            '(function(){ '+ code + '\n})()', sandbox, gMaxJSVersion, url, 1);
+        return;
       }
+      // Otherwise raise.
+      throw e;
     }
   }
 

--- a/modules/sandbox.js
+++ b/modules/sandbox.js
@@ -156,7 +156,7 @@ function injectGMInfo(aScript, sandbox, aContentWin) {
   function getScriptSource() {
     var content = fileCache.get("scriptSource");
     if (content === undefined) {
-      content = GM_util.fileXhr(scriptURL, "application/javascript");
+      content = GM_util.loadFile(scriptURL, "text/plain,charset=utf-8");
       fileCache.set("scriptSource", content);
     }
     return content;

--- a/modules/util.js
+++ b/modules/util.js
@@ -65,3 +65,4 @@ XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowId', 'chrome://greasemonkey-mo
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIsClosed', 'chrome://greasemonkey-modules/content/util/windowIsClosed.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIsPrivate', 'chrome://greasemonkey-modules/content/util/windowIsPrivate.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'writeToFile', 'chrome://greasemonkey-modules/content/util/writeToFile.js');
+XPCOMUtils.defineLazyModuleGetter(GM_util, 'loadFile', 'chrome://greasemonkey-modules/content/util/loadFile.js');

--- a/modules/util.js
+++ b/modules/util.js
@@ -45,6 +45,7 @@ XPCOMUtils.defineLazyModuleGetter(GM_util, 'hitch', 'chrome://greasemonkey-modul
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'inArray', 'chrome://greasemonkey-modules/content/util/inArray.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'installScriptFromSource', 'chrome://greasemonkey-modules/content/util/installScriptFromSource.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'isGreasemonkeyable', 'chrome://greasemonkey-modules/content/util/isGreasemonkeyable.js');
+XPCOMUtils.defineLazyModuleGetter(GM_util, 'loadFile', 'chrome://greasemonkey-modules/content/util/loadFile.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'logError', 'chrome://greasemonkey-modules/content/util/logError.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'memoize', 'chrome://greasemonkey-modules/content/util/memoize.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'newUserScript', 'chrome://greasemonkey-modules/content/util/newUserScript.js');
@@ -60,9 +61,8 @@ XPCOMUtils.defineLazyModuleGetter(GM_util, 'sniffGrants', 'chrome://greasemonkey
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'timeout', 'chrome://greasemonkey-modules/content/util/timeout.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'uriFromUrl', 'chrome://greasemonkey-modules/content/util/uriFromUrl.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'uuid', 'chrome://greasemonkey-modules/content/util/uuid.js');
-XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIdForEvent', 'chrome://greasemonkey-modules/content/util/windowIdForEvent.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowId', 'chrome://greasemonkey-modules/content/util/windowId.js');
+XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIdForEvent', 'chrome://greasemonkey-modules/content/util/windowIdForEvent.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIsClosed', 'chrome://greasemonkey-modules/content/util/windowIsClosed.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'windowIsPrivate', 'chrome://greasemonkey-modules/content/util/windowIsPrivate.js');
 XPCOMUtils.defineLazyModuleGetter(GM_util, 'writeToFile', 'chrome://greasemonkey-modules/content/util/writeToFile.js');
-XPCOMUtils.defineLazyModuleGetter(GM_util, 'loadFile', 'chrome://greasemonkey-modules/content/util/loadFile.js');

--- a/modules/util/loadFile.js
+++ b/modules/util/loadFile.js
@@ -45,7 +45,7 @@ function loadFile(url, mime, type) {
         break;
       default:
         // This would either throw later anyway, or actually crash the tab
-        throw new Error("Unsupported type");
+        throw new Error("Unsupported type '" + type + "'");
     }
     let result = cpmm.sendSyncMessage("greasemonkey:load-file", {
       url: url,

--- a/modules/util/loadFile.js
+++ b/modules/util/loadFile.js
@@ -38,6 +38,7 @@ function loadFile(url, mime, type) {
       case "":
       case "arraybuffer":
       case "json":
+      case "text":
         break;
       case "blob":
         etype = "arraybuffer";

--- a/modules/util/loadFile.js
+++ b/modules/util/loadFile.js
@@ -1,0 +1,63 @@
+"use strict";
+
+const {classes: Cc, interfaces: Ci, utils: Cu} = Components;
+Cu.import('chrome://greasemonkey-modules/content/constants.js');
+Cu.import('chrome://greasemonkey-modules/content/util.js');
+Cu.importGlobalProperties(["Blob"]);
+
+var EXPORTED_SYMBOLS = ['loadFile'];
+const remote = (function() {
+  if (!("@mozilla.org/xre/app-info;1" in Cc)) {
+    return false;
+  }
+  let runtime = Cc["@mozilla.org/xre/app-info;1"].getService(Ci.nsIXULRuntime);
+  return runtime.processType !== Ci.nsIXULRuntime.PROCESS_TYPE_DEFAULT;
+})();
+
+const cpmm = (function() {
+  try {
+    if (remote) {
+      return Cc["@mozilla.org/childprocessmessagemanager;1"].
+             getService(Ci.nsISyncMessageSender);
+    }
+  } catch (e) {
+   // fall through
+  }
+  return null;
+})();
+
+// Loads a file (from the scripts dir), whether being run in a child content
+// process or not
+function loadFile(url, mime, type) {
+  type = type || "";
+  mime = mime || "application/octet-stream";
+  if (remote) {
+    let etype = type;
+    switch (etype) {
+      case undefined:
+      case "":
+      case "arraybuffer":
+      case "json":
+        break;
+      case "blob":
+        etype = "arraybuffer";
+        break;
+      default:
+        // This would either throw later anyway, or actually crash the tab
+        throw new Error("Unsupported type");
+    }
+    let result = cpmm.sendSyncMessage("greasemonkey:load-file", {
+      url: url,
+      mime: mime,
+      type: etype});
+    result = result && result[0];
+    if (!result.result) {
+      throw new Error(result.error || "Unknown Error");
+    }
+    if (type === "blob") {
+      result.content = new Blob([result.content], {type: mime});
+    }
+    return result.content;
+  }
+  return GM_util.fileXhr(url, mime, type);
+}


### PR DESCRIPTION
Fixes #2485

Turns out the basic `@resource` handling stuff was easy enough, with a caveat:
It's not possible to structured-clone some `responseType`s. Of course, this didn't work before already, but when trying to structured-clone some types via IPC, the child process will actually crash o_O. This was the case too for `blob`, thus I opted to load that to as `ArrayBuffer` and reconstruct the `Blob` again child-side.

Tested in e10s windows, but also in non-e10s windows to make sure stuff didn't break.
I *think* I didn't use features above the `minVersion`...