### PR TITLE
"Unable to connect" page - throws an error

### DIFF
--- a/modules/remoteScript.js
+++ b/modules/remoteScript.js
@@ -162,12 +162,18 @@ DownloadListener.prototype = {
   onStartRequest: function(aRequest, aContext) {
     // For the first file (the script) detect an HTML page and abort if so.
     if (this._tryToParse) {
+      var contentType = false;
       try {
         aRequest.QueryInterface(Ci.nsIHttpChannel);
       } catch (e) {
         return;  // Non-http channel?  Ignore.
       }
-      if (this._htmlTypeRegex.test(aRequest.contentType)) {
+      try {
+        contentType = this._htmlTypeRegex.test(aRequest.contentType);
+      } catch (e) {
+        return;  // Problem loading page (Unable to connect)?  Ignore.
+      }
+      if (contentType) {
         // Cancel this request immediately and let onStopRequest handle the
         // cleanup for everything else.
         aRequest.cancel(Components.results.NS_BINDING_ABORTED);


### PR DESCRIPTION
It is a replacement for PR: https://github.com/greasemonkey/greasemonkey/pull/2415

"Unable to connect" page - Firefox throws an error in the Browser Console:

```
NS_ERROR_NOT_AVAILABLE: Component returned failure code: 0x80040111 (NS_ERROR_NOT_AVAILABLE)
[nsIChannel.contentType]
remoteScript.js:170
```

One example of a URL is (github.com => githubS.com):
https://githubs.com/anonim1133/wykop-userjs/blob/a86014414395f71e2b9f930cf8ec876374808c24/wykop-zawijas.user.js

---

See also HTTP Auth (https://github.com/greasemonkey/greasemonkey/pull/2430)
