### PR TITLE
FF 57 (with XUL/XPCOM - which it still supports): nsIURI.path renamed to nsIURI.pathQueryRef

### DIFF
--- a/modules/script.js
+++ b/modules/script.js
@@ -847,7 +847,14 @@ Script.prototype.checkForRemoteUpdate = function(aCallback, aForced) {
 
   var usedMeta = false;
   if (this._updateMetaStatus != 'fail') {
-    uri.path = uri.path.replace('.user.js', '.meta.js');
+    let exts = ['.user.js', '.meta.js'];
+    // See #2536
+    // http://bugzil.la/1326520
+    if (uri.path) {
+      uri.path = uri.path.replace(exts[0], exts[1]);
+    } else {
+      uri.pathQueryRef = uri.pathQueryRef.replace(exts[0], exts[1]);
+    }
     usedMeta = true;
   }
   var url = uri.spec;

--- a/modules/third-party/MatchPattern.js
+++ b/modules/third-party/MatchPattern.js
@@ -125,6 +125,9 @@ MatchPattern.prototype.doMatch = function(uriSpec) {
   if (this._scheme != '*' && this._scheme != matchURI.scheme) {
     return false;
   }
+  // See #2536
+  // http://bugzil.la/1326520
   return this._hostExpr.test(matchURI.host)
-      && this._pathExpr.test(matchURI.path);
+      && this._pathExpr.test(
+          matchURI.path ? matchURI.path : matchURI.pathQueryRef);
 };


### PR DESCRIPTION
Ad #2536 