### PR TITLE
FF 57 (with XUL/XPCOM - which it still supports)

### DIFF
--- a/modules/prefmanager.js
+++ b/modules/prefmanager.js
@@ -135,8 +135,15 @@ GM_PrefManager.prototype.watch = function(prefName, watcher) {
   // store the observer in case we need to remove it later
   this.observers.set(watcher, observer);
 
-  this.pref.QueryInterface(Components.interfaces.nsIPrefBranchInternal)
-      .addObserver(prefName, observer, false);
+  // http://bugzil.la/1374847
+  let _pref = null;
+  try {
+    _pref = this.pref.QueryInterface(
+        Components.interfaces.nsIPrefBranchInternal);
+  } catch (e) {
+    _pref = this.pref.QueryInterface(Components.interfaces.nsIPrefBranch);
+  }
+  _pref.addObserver(prefName, observer, false);
 };
 
 /**
@@ -146,8 +153,15 @@ GM_PrefManager.prototype.unwatch = function(prefName, watcher) {
   var obs = this.observers.get(watcher);
   if (obs) {
     this.observers.delete(watcher);
-    this.pref.QueryInterface(Components.interfaces.nsIPrefBranchInternal)
-        .removeObserver(prefName, obs);
+    // http://bugzil.la/1374847
+    let _pref = null;
+    try {
+      _pref = this.pref.QueryInterface(
+          Components.interfaces.nsIPrefBranchInternal);
+    } catch (e) {
+      _pref = this.pref.QueryInterface(Components.interfaces.nsIPrefBranch);
+    }
+    _pref.removeObserver(prefName, obs);
   }
 };
 

--- a/modules/script.js
+++ b/modules/script.js
@@ -847,7 +847,14 @@ Script.prototype.checkForRemoteUpdate = function(aCallback, aForced) {
 
   var usedMeta = false;
   if (this._updateMetaStatus != 'fail') {
-    uri.path = uri.path.replace('.user.js', '.meta.js');
+    let exts = ['.user.js', '.meta.js'];
+    // See #2536
+    // http://bugzil.la/1326520
+    if (uri.path) {
+      uri.path = uri.path.replace(exts[0], exts[1]);
+    } else {
+      uri.pathQueryRef = uri.pathQueryRef.replace(exts[0], exts[1]);
+    }
     usedMeta = true;
   }
   var url = uri.spec;

--- a/modules/third-party/MatchPattern.js
+++ b/modules/third-party/MatchPattern.js
@@ -125,6 +125,9 @@ MatchPattern.prototype.doMatch = function(uriSpec) {
   if (this._scheme != '*' && this._scheme != matchURI.scheme) {
     return false;
   }
+  // See #2536
+  // http://bugzil.la/1326520
   return this._hostExpr.test(matchURI.host)
-      && this._pathExpr.test(matchURI.path);
+      && this._pathExpr.test(
+          matchURI.path ? matchURI.path : matchURI.pathQueryRef);
 };


### PR DESCRIPTION
## 1)

__FF 57: nsIURI.path renamed to nsIURI.pathQueryRef__
Ad #2536 (#2540)

## 2)

__FF 57: Remove nsIPrefBranchInternal__

Throws an error in Browser Console:
```
NS_ERROR_XPC_BAD_CONVERT_JS:
Could not convert JavaScript argument arg 0 [nsISupports.QueryInterface]
prefmanager.js:138
```

See:
https://bugzilla.mozilla.org/show_bug.cgi?id=1374847
