### PR TITLE
Only update tab if the script uuid matches

### DIFF
--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -64,7 +64,8 @@ chrome.runtime.sendMessage({
 
 
 function onUserScriptChanged(message, sender, sendResponse) {
-  if (message.name != 'UserScriptChanged') return;
+  if (message.name != 'UserScriptChanged' ||
+      message.details.uuid != userScriptUuid) return;
   let details = message.details;
 
   document.title = titlePattern.replace('%s', details.name);


### PR DESCRIPTION
This actually fixes two problems. Although one of them was unintended and I'm not exactly sure why.

Anyway, the problem.

1. Have two (or more) user scripts installed.
2. Open the editor for one of them through the Monkey Menu.
3. Now open the editor for the second one.
4. Make a change and save (ctrl+s) in the second editor tab.
5. The tab information (e.g. title) changes for the tab that was not saved.
6. If you go back to the first tab, saving (ctrl+s) is broken. It opens the Firefox 'save page' window. ***

*** This fix was originally to resolve number 5 in the list. However, it seems to have fixed number 6 as well. And I can't explain why.
