### PR TITLE
Fix undefined MatchPattern on parse script

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -43,6 +43,8 @@
   "content_scripts": [{
     "matches": ["*://*/*.user.js"],
     "js": [
+      "src/third-party/convert2RegExp.js",
+      "src/third-party/MatchPattern.js",
       "src/bg/api-provider-source.js",
       "src/parse-meta-line.js",
       "src/parse-user-script.js",


### PR DESCRIPTION
When navigating to a page hosting a user script the extension should parse the script and offer to install should it be valid. If the [script](https://github.com/Sxderp/matchpattern-user-test/raw/master/mp-undefined.user.js) has a `// @match` the parse script function fails at [creating a MatchPattern](https://github.com/greasemonkey/greasemonkey/blob/10f3ef620c21865cf1db778b4cfd193d31a7f20e/src/parse-user-script.js#L102) object with the following error:

```
parse-user-script.js:105:15

Error: Ignoring @match pattern https://*.google.com/foo*bar because:
ReferenceError: MatchPattern is not defined
```

The reason is that `parseUserScript()` is being run as a content_script and therefore does not have access to the MatchPattern object, as defined in the [manifest.json](https://github.com/greasemonkey/greasemonkey/blob/10f3ef620c21865cf1db778b4cfd193d31a7f20e/manifest.json#L25-L26). Further, if the convert2RegExp file isn't added the MatchPattern object constructor will fail.