### PR TITLE
Normalize install button sizes

### DIFF
--- a/src/content/install-dialog.css
+++ b/src/content/install-dialog.css
@@ -84,4 +84,5 @@ progress {
 }
 #footer button {
   flex-grow: 3;
+  width: 0;
 }


### PR DESCRIPTION
On the install script dialog page the buttons are not the exact same size. This is due to some weird flex-box parsing and the contents of the elements that have 'flex-grow' set. Turns out setting [width: 0](https://stackoverflow.com/a/7985973) on the elements fixes the issue and they become the same size.