### PR TITLE
package.sh: other providers for getting version

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -3,7 +3,18 @@
 set -e
 set -x
 
-VER=$(sed -n -e '/"version"/{ s/.*: "//; s/".*//; p; q}' manifest.json)
+function get_version {
+  while read line ; do
+    if [[ "$line" == *\"version\"* ]]; then
+      line="${line##*: \"}"
+      line="${line%%\"*}"
+      echo "$line"
+      break
+    fi
+  done < manifest.json
+}
+
+VER=$(get_version)
 
 zip -r -9 greasemonkey-${VER}.xpi \
   _locales skin src LICENSE.mit manifest.json


### PR DESCRIPTION
package.sh tries to extract the version from manifest.json.
Unfortunately the method used is specific to GNU sed, so the command
fails on OS X and other operating systems with the BSD userland.

Add in a few other options for one-liners for just grabbing the version
out:

  jq: the best as it can actually just parse the json
  gsed: if this is available, it should for sure be GNU sed, often
        BSDs will install GNU sed under this name.
  perl: Available almost everywhere and will also do the trick

And last, if nothing else is available, fall back on the original
sed command which usually only works on linux and certain windows
environments.