### PR TITLE
package.sh: use bash directly for getting version

### DIFF
--- a/package.sh
+++ b/package.sh
@@ -3,7 +3,18 @@
 set -e
 set -x
 
-VER=$(sed -n -e '/"version"/{ s/.*: "//; s/".*//; p; q}' manifest.json)
+function get_version {
+  while read line ; do
+    if [[ "$line" == *\"version\"* ]]; then
+      line="${line##*: \"}"
+      line="${line%%\"*}"
+      echo "$line"
+      break
+    fi
+  done < manifest.json
+}
+
+VER=$(get_version)
 
 zip -r -9 greasemonkey-${VER}.xpi \
   _locales skin src LICENSE.mit manifest.json


### PR DESCRIPTION
package.sh tries to extract the version from manifest.json.
Unfortunately the method used is specific to GNU sed, so the command
fails on OS X and other operating systems with the BSD userland.

Since we're already depending on bash, just use bash directly to extract
the version.  It isn't pretty but avoids external dependencies (besides
zip, of course).