### PR TITLE
Parse migration values. Fixes #2600

### DIFF
--- a/content/config.js
+++ b/content/config.js
@@ -490,7 +490,7 @@ Config.prototype._convertScriptToWebext = function(script) {
   let storage = new GM_ScriptStorageBack(script);
   let names = storage.listValues();
   for (let i = 0, name = null; name = names[i]; i++) {
-    let val = storage.getValue(name);
+    let val = JSON.parse(storage.getValue(name));
     this.migrateSetValue(script, name, val);
   }
 }


### PR DESCRIPTION
[See my comment in the issue.](https://github.com/greasemonkey/greasemonkey/issues/2600#issuecomment-333315111)

An additional note. While this fixes the initial issue, there's still the problem of scripts that have already been migrated and are suffering from the problem. Since already migrated scripts are [skipped](https://github.com/greasemonkey/greasemonkey/blob/3.x/content/config.js#L414-L418).