### PR TITLE
Add missing info to GM.Info per docs

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -250,18 +250,27 @@ window.EditableUserScript = class EditableUserScript
     let gmInfo = {
       'script': {
         'description': this.description,
+        'excludes': this.excludes,
+        'includes': this.includes,
+        'matches': this.matches,
         'name': this.name,
         'namespace': this.namespace,
         'resources': {},
+        'runAt': this.runAt,
+        'uuid': this.uuid,
         'version': this.version,
       },
+      'scriptMetaStr': extractMeta(this.content),
       'scriptHandler': 'Greasemonkey',
-      'uuid': this.uuid,
       'version': extensionVersion,
     };
     Object.keys(this.resources).forEach(n => {
       let r = this.resources[n];
-      gmInfo.script.resources[n] = {'name': r.name, 'mimetype': r.mimetype};
+      gmInfo.script.resources[n] = {
+        'name': r.name,
+        'mimetype': r.mimetype,
+        'url': r.url || "",
+      };
     });
     return 'const GM = {};\n'
         + 'GM.info=' + JSON.stringify(gmInfo) + ';'
@@ -310,6 +319,7 @@ window.EditableUserScript = class EditableUserScript
               this._resources[n] = {
                   'name': n,
                   'mimetype': d.xhr.getResponseHeader('Content-Type'),
+                  'url': d.url,
                   'blob': d.xhr.response,
               };
             });


### PR DESCRIPTION
#2627, #2628

Added missing keys per Greasemoneky documentation wiki:
https://wiki.greasespot.net/GM_info

Three keys were not implemented.

isPrivate; a function fo the current tab, and therefore cannot be
cached.
scriptWillUpdate; There doesn't seem to be a property that defines
if a script is slated for autoupdate.
unwrap; ??

---

Of note, the uuid key was moved under the script key. It didn't make much sense that the _script_ uuid was not part of 'script'.

Of further note, this will solve the problems for new scripts but since the data is cached the `GM.Info` object will not be updated until the scripts are resaved. Even more nuanced, the resource objects won't be updated to include the url until they are each modified and saved.