### PR TITLE
Fix not saving noframes by setting default

### DIFF
--- a/src/parse-user-script.js
+++ b/src/parse-user-script.js
@@ -43,6 +43,7 @@ window.parseUserScript = function(content, url, failIfMissing) {
     'matches': [],
     'name': nameFromUrl(url),
     'namespace': new URL(url).host,
+    'noFrames': false,
     'requireUrls': [],
     'resourceUrls': {},
     'runAt': 'end'


### PR DESCRIPTION
If a script which had the noframes metablock item and then it were
to remove it the old value (noframes=true) would remain. This
fixes that issue by configuring a default value for noframes.