### PR TITLE
Update userscript object enabled on toggle

### DIFF
--- a/src/browser/monkey-menu.js
+++ b/src/browser/monkey-menu.js
@@ -91,6 +91,7 @@ window.addEventListener('click', function(event) {
         'name': 'UserScriptToggleEnabled',
         'uuid': gActiveUuid,
       }, response => {
+        gUserScripts[gActiveUuid].enabled = response.enabled;
         gTplData.activeScript.enabled = response.enabled;
         tplItemForUuid(gActiveUuid).enabled = response.enabled;
       });


### PR DESCRIPTION
For #2638.
When constructing the submenu for an individual script the [original script objects](https://github.com/greasemonkey/greasemonkey/blob/eacbd15801dca70d3be0e444689dba333dc5f0c7/src/browser/monkey-menu.js#L74-L78) are used. These were not updated when toggling enable / disable.