### PR TITLE
Gracefully fail _testMatch if bad type is passed

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -32,6 +32,9 @@ function _testClude(glob, url) {
 function _testMatch(matchPattern, url) {
   if ('string' == typeof matchPattern) {
     matchPattern = new MatchPattern(matchPattern);
+  } else if (MatchPattern != typeof matchPattern) {
+    console.error('matchPattern is not a string nor MatchPattern object:', matchPattern);
+    return false;
   }
   return matchPattern.doMatch(url);
 }


### PR DESCRIPTION
See #2651.
Doesn't solve the issue but does allow for graceful failure.
