### PR TITLE
Fix failing with trailing comments in scripts

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -249,10 +249,7 @@ window.EditableUserScript = class EditableUserScript
     // of the generated parts.
     this._evalContent
         // Note intentional lack of line breaks before the script content.
-        = `try {
-        (function scopeWrapper(){
-        function userScript() {
-        ${this._content}
+        = `try { (function scopeWrapper(){ function userScript() { ${this._content}
         /* catch open comment blocks */ }
         const unsafeWindow = window.wrappedJSObject;
         ${this.calculateGmInfo()}

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -9,7 +9,7 @@ reference any other objects from this file.
 // Increment this number when updating `calculateEvalContent()`.  If it
 // is higher than it was when eval content was last calculated, it will
 // be re-calculated.
-const EVAL_CONTENT_VERSION = 5;
+const EVAL_CONTENT_VERSION = 6;
 
 
 // Private implementation.
@@ -249,7 +249,11 @@ window.EditableUserScript = class EditableUserScript
     // of the generated parts.
     this._evalContent
         // Note intentional lack of line breaks before the script content.
-        = `try { (function scopeWrapper(){ function userScript() { ${this._content} }
+        = `try {
+        (function scopeWrapper(){
+        function userScript() {
+        ${this._content}
+        /* catch open comment blocks */ }
         const unsafeWindow = window.wrappedJSObject;
         ${this.calculateGmInfo()}
         ${apiProviderSource(this)}

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -250,7 +250,7 @@ window.EditableUserScript = class EditableUserScript
     this._evalContent
         // Note intentional lack of line breaks before the script content.
         = `try { (function scopeWrapper(){ function userScript() { ${this._content}
-        /* catch open comment blocks */ }
+        /* Line break to catch comments on the final line of scripts. */ }
         const unsafeWindow = window.wrappedJSObject;
         ${this.calculateGmInfo()}
         ${apiProviderSource(this)}


### PR DESCRIPTION
See #2670 

When a user script had a trailing comment it would comment out part
of the eval string. Catch them so they don't interfere.