### PR TITLE
Don't allow selectable text in the monkey menu and tabs in script editor

### DIFF
--- a/src/browser/monkey-menu.css
+++ b/src/browser/monkey-menu.css
@@ -15,6 +15,7 @@ body #menu, body.detail #user-script-detail { display: block; }
   display: flex;
   flex-direction: row;
   padding: 4px 8px;
+  -moz-user-select: none;
 }
 .menu-item * {
   vertical-align: middle;

--- a/src/content/edit-user-script.css
+++ b/src/content/edit-user-script.css
@@ -26,6 +26,7 @@ html, body {
   margin: 0;
   margin-left: 1ex;
   padding: 4px 8px;
+  -moz-user-select: none;
 }
 #tabs .tab.active {
   background: white;


### PR DESCRIPTION
Small UI fix. You can't select text with the cursor in the money menu or the tab on the editor page anymore.