### PR TITLE
Issue #2690 Define a codemirror "save" command

### DIFF
--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -6,11 +6,10 @@ var editor = CodeMirror(
     // TODO: Make appropriate options user-configurable.
     {
       'tabSize': 2,
-      'extraKeys': {
-        'Ctrl-S': onSave,
-      },
       'lineNumbers': true,
     });
+
+CodeMirror.commands.save = onSave;
 
 const titlePattern = '%s - Greasemonkey User Script Editor';
 const userScriptUuid = location.hash.substr(1);


### PR DESCRIPTION
CodeMirror's default keymap already handles 'ctrl-s' and even runs
a 'save' command when available.

see docs
https://codemirror.net/doc/manual.html#commands