### PR TITLE
Fix GM.xhr onprogress event is not working

### DIFF
--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -55,9 +55,9 @@ function open(xhr, d, port) {
 
     switch (event.type) {
       case "progress":
-        responseState.lengthComputable = evt.lengthComputable;
-        responseState.loaded = evt.loaded;
-        responseState.total = evt.total;
+        responseState.lengthComputable = event.lengthComputable;
+        responseState.loaded = event.loaded;
+        responseState.total = event.total;
         break;
       case "error":
         console.log('error event?', event);


### PR DESCRIPTION
This should fix #2712, the problem is due to referencing an incorrect variable `evt` instead of declared `event`.