### PR TITLE
Allow user to set forbidden headers in XHR

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -65,6 +65,8 @@
     "storage",
     "tabs",
     "unlimitedStorage",
-    "webNavigation"
+    "webNavigation",
+    "webRequest",
+    "webRequestBlocking"
   ]
 }

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -99,7 +99,7 @@ function open(xhr, d, port) {
   d.overrideMimeType && xhr.overrideMimeType(d.overrideMimeType);
   d.responseType && (xhr.responseType = d.responseType);
   d.timeout && (xhr.timeout = d.timeout);
-  
+
   if (d.headers) {
     for (var prop in d.headers) {
       if (Object.prototype.hasOwnProperty.call(d.headers, prop)) {

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -21,7 +21,7 @@ function onUserScriptXhr(port) {
 chrome.runtime.onConnect.addListener(onUserScriptXhr);
 
 var headersToReplace = ['origin', 'referer'];
-var dummyHeaderPrefix = "x-greasemonkey-";
+var dummyHeaderPrefix = 'x-greasemonkey-';
   
 function open(xhr, d, port) {
   function xhrEventHandler(src, event) {
@@ -137,18 +137,18 @@ function getHeader(headers, name) {
   return null;
 }
 
-var extensionUrl = browser.extension.getURL("");
+const extensionUrl = chrome.extension.getURL('');
 
 function rewriteHeaders(e) {
   if (e.originUrl && e.originUrl.startsWith(extensionUrl)) {
     for (var name of headersToReplace) {
       var prefixedHeader = getHeader(e.requestHeaders, dummyHeaderPrefix + name);
       if (prefixedHeader) {
-        if (!getHeader(e.requestHeaders, name)) {
-          // only try to add real header if request doesn't already have it
-          e.requestHeaders.push({name: name, value: prefixedHeader.value});
+        var unprefixedHeader = getHeader(e.requestHeaders, name);
+        if (unprefixedHeader) {
+          e.requestHeaders.splice(e.requestHeaders.indexOf(unprefixedHeader), 1);
         }
-        // remove the prefixed header regardless
+        e.requestHeaders.push({name: name, value: prefixedHeader.value});
         e.requestHeaders.splice(e.requestHeaders.indexOf(prefixedHeader), 1);
       }
     }
@@ -156,8 +156,8 @@ function rewriteHeaders(e) {
   return { requestHeaders: e.requestHeaders };
 }
 
-browser.webRequest.onBeforeSendHeaders.addListener(
-  rewriteHeaders, {urls: ["<all_urls>"], types: ["xmlhttprequest"]}, ["blocking", "requestHeaders"]
+chrome.webRequest.onBeforeSendHeaders.addListener(
+  rewriteHeaders, {urls: ['<all_urls>'], types: ['xmlhttprequest']}, ['blocking', 'requestHeaders']
 );
 
 })();

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -140,7 +140,7 @@ function rewriteHeaders(e) {
 }
 
 browser.webRequest.onBeforeSendHeaders.addListener(
-  rewriteHeaders, {urls: ["<all_urls>"]}, ["blocking", "requestHeaders"]
+  rewriteHeaders, {urls: ["<all_urls>"], types: ["xmlhttprequest"]}, ["blocking", "requestHeaders"]
 );
 
 })();


### PR DESCRIPTION
Even in WebExtensions, Firefox enforces [per spec](https://fetch.spec.whatwg.org/#forbidden-header-name) that Referer, Origin, and other headers may not be set by the developer on the XHR object. However, if the outgoing XHR is intercepted in the `onBeforeSendHeaders` event, it is possible to set these headers as desired.

~~This is a WIP~~ This change currently looks for Referer and Origin and shows how GM can set the header values when the user supplies them the normal way, through the `headers` property of the object passed to `GM.xmlHttpRequest`. It's necessary for GM to add dummy headers to preserve the user's header values until `onBeforeSendHeaders`, at which point we can set the real header and delete the dummy.

Fixes https://github.com/greasemonkey/greasemonkey/issues/2599