### PR TITLE
Fix logical flaw from 7d1f1b98

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -32,7 +32,7 @@ function _testClude(glob, url) {
 function _testMatch(matchPattern, url) {
   if ('string' == typeof matchPattern) {
     matchPattern = new MatchPattern(matchPattern);
-  } else if (MatchPattern != typeof matchPattern) {
+  } else if (!(matchPattern instanceof MatchPattern)) {
     console.error('matchPattern is not a string nor MatchPattern object:', matchPattern);
     return false;
   }


### PR DESCRIPTION
The initial change fixed the problem but only as a side effect that
typeof returned 'object' for everything. Therefore any object would
fail the comparison and get caught.