### PR TITLE
Make `GM.openInTab` open a tab in a correct place in Firefox 57+.

### DIFF
--- a/src/bg/on-user-script-open-in-tab.js
+++ b/src/bg/on-user-script-open-in-tab.js
@@ -5,11 +5,18 @@ This file is responsible for providing the GM.openInTab API method.
 function onApiOpenInTab(message, sender, sendResponse) {
   checkApiCallAllowed('GM.openInTab', message.uuid);
   const senderTab = sender.tab;
-  chrome.tabs.create({
+  const tab = {
     url: message.url,
     active: message.active,
-    windowId: senderTab.windowId,
-    index: senderTab.index + 1, // next to senderTab
-    openerTabId: senderTab.id,
+  };
+  chrome.runtime.getBrowserInfo(browserInfo => {
+    if (browserInfo.name === 'Firefox' && browserInfo.version.split('.')[0] < 57) {
+      tab.windowId = senderTab.windowId;
+      tab.index = senderTab.index + 1; // next to senderTab
+    } else {
+      tab.openerTabId = senderTab.id;
+    }
+
+    chrome.tabs.create(tab);
   });
 };


### PR DESCRIPTION
Fixes https://github.com/greasemonkey/greasemonkey/issues/2672 .

This uses `openerTabId` property of `tabs.create()` that implemented in Firefox 57.
https://developer.mozilla.org/Add-ons/WebExtensions/API/tabs/create

### Script used by test

```javascript
// ==UserScript==
// @name     GM.openInTab() Test
// @version  1
// @match    https://github.com/greasemonkey/greasemonkey/issues/2672
// @grant    GM.openInTab
// ==/UserScript==

const parent = document.getElementsByClassName('gh-header-show')[0];
parent.insertAdjacentHTML('beforeend', `
  <button name="open-in-background-tab">Open the wiki in background tab</button>
  <button name="open-in-active-tab">Open the wiki in active tab</button>
`);

parent.addEventListener('click', function (event) {
  switch (event.target.name) {
    case 'open-in-background-tab':
      GM.openInTab('https://wiki.greasespot.net/GM.openInTab');
      break;
    case 'open-in-active-tab':
      GM.openInTab('https://wiki.greasespot.net/GM.openInTab', false);
      break;
   }
});
```