### PR TITLE
Remove CodeMirror flexbox style

### DIFF
--- a/src/content/edit-user-script.css
+++ b/src/content/edit-user-script.css
@@ -36,14 +36,17 @@ html, body {
 }
 
 
-body, #editor, .CodeMirror {
+body, #editor {
   display: flex;
   flex-direction: column;
   flex: 1 1 auto;
   flex-basis: fill;
 
 }
-#editor .CodeMirror {
+#editor {
   height: 0;
   background: white;
+}
+.CodeMirror {
+  height: 100% !important;
 }


### PR DESCRIPTION
The editor has a layout issue that is affecting typing speed. Removing `display: flex` from the `.CodeMirror` selector should fix this.