### PR TITLE
Add onMessage tests

### DIFF
--- a/doc/Messages.md
+++ b/doc/Messages.md
@@ -67,17 +67,6 @@ Data:
 * `uuid` The UUID of an installed script which is storing this value.
 * `value` The new value to store.
 
-# EditorSaved
-Sent by: `content/edit-user-script.js`.
-Received by: `bg/user-script-registry.js`.
-
-Sent whenever the user triggers the save action in the user script editor.
-Data:
-
-* `uuid` String UUID of the script being edited.
-* `content` String text content of main script.
-* `requires` Object mapping require URL to text content.
-
 # EnabledQuery
 Received by: `bg/is-enabled.js`.
 
@@ -117,25 +106,6 @@ progress as a percentage.  Sent specifically back to the content process
 
 * `errors` A (possibly empty) list of string error messages.
 * `progress` A number, 0.0 to 1.0, representing the completion so far.
-
-# UserScriptChanged
-Sent by: `bg/user-script-registry.js`
-
-Sent when some value (like enabled state) of a script is changed.  Data:
-
-* `details` Updated script's current.
-* `parsedDetails` Updated script's original parsed details.
-
-# UserScriptGet
-Sent by: `content/edit-user-script.js`
-
-Data:
-
-* `uuid` The UUID of an installed script to fetch.
-
-Response:
-
-* `details` The details object from an `EditableUserScript`.
 
 # UserScriptInstall
 Sent by: `content/install-dialog.js`

--- a/doc/Messages.md
+++ b/doc/Messages.md
@@ -78,13 +78,6 @@ Data:
 * `content` String text content of main script.
 * `requires` Object mapping require URL to text content.
 
-# EnabledChanged
-Sent by: `bg/is-enabled.js`.
-
-Sent whenever the global enabled status changes.
-
-* `enabled` boolean, the new status (true = enabled, false = disabled).
-
 # EnabledQuery
 Received by: `bg/is-enabled.js`.
 

--- a/doc/Ports.md
+++ b/doc/Ports.md
@@ -1,0 +1,50 @@
+This document keeps track of all the parent/child ports that Greasemonkey
+creates. All sections should look like:
+
+    # PortName
+    Sent by: `creator.js`
+    Received by: `listener.js`
+
+    Description of the purpose of this port, its important details, incoming
+    and outgoing message schema and expected responses. Message names are not
+    necessarily included when sending message but are intended to be used as
+    a labeling mechanism for the documentation.
+
+    An additional note on identifying message direction. Incoming messages are
+    sent from `creator.js` to `listener.js`. While outgoing messages are the
+    reverse.
+
+All message should specify `JSON.parse()`-able bodies, and always with a `name`
+parameter for dispatching.  Additional values are documented per message name
+below.
+
+# EditorConnect
+Sent by: `content/edit-user-script.js`
+Received by: `bg/on-editor-connect.js`
+
+_Incoming Messages_
+**open**
+Triggered when the user script editor opens.
+
+* `uuid` The UUID of an installed script to fetch.
+Expects **userscript**
+
+**save**
+Triggered when the editor is saved.
+
+* `uuid` The UUID of the saved script.
+* `content` String text content of main script.
+* `requires` Object mapping require URL to text content.
+Expects **change**
+
+_Outgoing Messages_
+**userscript**
+Sent after estabishing the port connection.
+
+* `details` The details object from an `EditableUserScript`.
+
+**change**
+Sent after saving the user script.
+
+* `details` Updated script's current.
+* `parsedDetails` Updated script's original parsed details.

--- a/manifest.json
+++ b/manifest.json
@@ -22,6 +22,8 @@
 
   "background": {
     "scripts": [
+      "src/bg/_init.js",
+
       "src/bg/api-provider-source.js",
       "src/bg/execute.js",
       "src/bg/is-enabled.js",

--- a/manifest.json
+++ b/manifest.json
@@ -27,6 +27,7 @@
       "src/bg/api-provider-source.js",
       "src/bg/execute.js",
       "src/bg/is-enabled.js",
+      "src/bg/on-editor-connect.js",
       "src/bg/on-message.js",
       "src/bg/on-user-script-notification.js",
       "src/bg/on-user-script-open-in-tab.js",

--- a/src/bg/_init.js
+++ b/src/bg/_init.js
@@ -1,0 +1,5 @@
+/* Initialize objects that need to be created first, like namespace
+ * objects
+ */
+
+window.Message = {};

--- a/src/bg/is-enabled.js
+++ b/src/bg/is-enabled.js
@@ -23,13 +23,11 @@ window.Message.onEnabledQuery = onEnabledQuery;
 
 function setGlobalEnabled(enabled) {
   isEnabled = !!enabled;
-  chrome.runtime.sendMessage({
-    'name': 'EnabledChanged',
-    'enabled': isEnabled,
-  });
   setIcon();
 }
 window.setGlobalEnabled = setGlobalEnabled;
+
+
 function onEnabledSet(message, sender, sendResponse) {
   setGlobalEnabled(message.enabled);
 }

--- a/src/bg/is-enabled.js
+++ b/src/bg/is-enabled.js
@@ -18,7 +18,7 @@ window.getGlobalEnabled = getGlobalEnabled;
 function onEnabledQuery(message, sender, sendResponse) {
   sendResponse(isEnabled);
 }
-window.onEnabledQuery = onEnabledQuery;
+window.Message.onEnabledQuery = onEnabledQuery;
 
 
 function setGlobalEnabled(enabled) {
@@ -33,7 +33,7 @@ window.setGlobalEnabled = setGlobalEnabled;
 function onEnabledSet(message, sender, sendResponse) {
   setGlobalEnabled(message.enabled);
 }
-window.onEnabledSet = onEnabledSet;
+window.Message.onEnabledSet = onEnabledSet;
 
 
 function setIcon() {
@@ -56,6 +56,6 @@ function onEnabledToggle(message, sender, sendResponse) {
   sendResponse(isEnabled);
   } catch (e) { console.error(e); }
 }
-window.onEnabledToggle = onEnabledToggle;
+window.Message.onEnabledToggle = onEnabledToggle;
 
 })();

--- a/src/bg/on-editor-connect.js
+++ b/src/bg/on-editor-connect.js
@@ -1,0 +1,49 @@
+/*
+This file is responsible for communicating with the GM built in editor.
+*/
+
+// Private implementation.
+(function() {
+
+function onEditorConnect(port) {
+  if (port.name != 'EditorConnect') return;
+
+  port.onMessage.addListener(msg => {
+    switch (msg.type) {
+      case 'open':
+        open(msg.uuid, port);
+        break;
+      case 'save':
+        save(msg.uuid, msg, port);
+        break;
+      default:
+        console.warn('EditorConnect port un-handled message type:', msg.type);
+    }
+  });
+}
+chrome.runtime.onConnect.addListener(onEditorConnect);
+
+
+function open(uuid, port) {
+  let scriptDetails = UserScriptRegistry.getScript(uuid);
+  if (scriptDetails) {
+    scriptDetails = scriptDetails.details;
+  }
+
+  port.postMessage({
+    'type': 'userscript',
+    'details': scriptDetails,
+  });
+}
+
+
+async function save(uuid, msg, port) {
+  let script = await UserScriptRegistry.scriptEditorSave(uuid, msg);
+  port.postMessage({
+    'type': 'change',
+    'details': script.details,
+    'parsedDetails': script.parsedDetails,
+  });
+}
+
+})();

--- a/src/bg/on-message.js
+++ b/src/bg/on-message.js
@@ -8,7 +8,7 @@ and passes all arguments on to that callback.
 (function() {
 const myPrefix = chrome.runtime.getURL('');
 
-chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
+function onMessage(message, sender, sendResponse) {
   if (!message.name) {
     console.error('Background received message without name!', message, sender);
     return;
@@ -23,7 +23,7 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
         + `message from sender "${sender.url}".`);
   }
 
-  var cb = window['on' + message.name];
+  var cb = window.Message['on' + message.name];
   if (!cb) {
     console.error(
         'Background has no callback for message:', message, 'sender:', sender);
@@ -31,6 +31,8 @@ chrome.runtime.onMessage.addListener(function(message, sender, sendResponse) {
   }
 
   return cb(message, sender, sendResponse);
-});
+}
+window.onMessage = onMessage;
+chrome.runtime.onMessage.addListener(onMessage);
 
 })();

--- a/src/bg/on-user-script-open-in-tab.js
+++ b/src/bg/on-user-script-open-in-tab.js
@@ -2,6 +2,8 @@
 This file is responsible for providing the GM.openInTab API method.
 */
 
+(function() {
+
 function onApiOpenInTab(message, sender, sendResponse) {
   const senderTab = sender.tab;
   chrome.tabs.create({
@@ -11,3 +13,6 @@ function onApiOpenInTab(message, sender, sendResponse) {
     index: senderTab.index + 1, // next to senderTab
   });
 };
+window.Message.onApiOpenInTab = onApiOpenInTab;
+
+})();

--- a/src/bg/user-script-install.js
+++ b/src/bg/user-script-install.js
@@ -2,7 +2,7 @@
 (function() {
 
 /// Receive a UserScriptInstall message.
-window.onUserScriptInstall = async function(message, sender) {
+async function onUserScriptInstall(message, sender) {
   if (message.details) {
     let downloader = new Downloader(message.details, sender);
     downloader.start(function() {
@@ -14,6 +14,7 @@ window.onUserScriptInstall = async function(message, sender) {
     return await UserScriptRegistry.installFromSource(message.source);
   }
 }
+window.Message.onUserScriptInstall = onUserScriptInstall;
 
 
 class Downloader {

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -126,8 +126,12 @@ function onEditorSaved(message, sender, sendResponse) {
     return;
   }
 
-  userScript.updateFromEditorSaved(message)
-      .then(value => saveUserScript(userScript));
+  // Use a clone of the current user script. This is so that any changes are
+  // not propegated to the actual UserScript unless the transaction is
+  // successful.
+  let cloneScript = new EditableUserScript(userScript.details);
+  cloneScript.updateFromEditorSaved(message)
+      .then(value => saveUserScript(cloneScript));
 };
 window.Message.onEditorSaved = onEditorSaved;
 
@@ -224,17 +228,11 @@ function saveUserScript(userScript) {
       // In case this was for an install, now that the user script is saved
       // to the object store, also put it in the in-memory copy.
       userScripts[userScript.uuid] = userScript;
-
-      chrome.runtime.sendMessage({
-        'name': 'UserScriptChanged',
-        'details': userScript.details,
-        'parsedDetails': userScript.parsedDetails,
-      });
       resolve();
     };
     txn.onerror = event => {
       console.warn('save transaction error?', event, event.target);
-      reject();
+      reject(event.target.error);
     };
 
     try {
@@ -247,7 +245,32 @@ function saveUserScript(userScript) {
       console.error('when saving', userScript, e);
       return;
     }
-  }));
+  })).catch(err => {
+    // If the transaction had an error of some sort..
+    let message;
+    if (err.name == 'ConstraintError') {
+      // Most likely due to namespace / name conflict.
+      message = 'Failed to save: namespace/name already exists: '
+              + userScript.id;
+    } else {
+      message = 'Failed to save: ' + userScript.id + ': Unknown error';
+    }
+    browser.notifications.create({
+      'type': 'basic',
+      'title': 'Script Save Error',
+      'message': message,
+      // contextMessage doesn't currently display anything. Firefox bug?
+      'contextMessage': err.message
+    });
+  }).then(() => {
+    // Send the script change event, even though the save may have failed.
+    // This way the editor gets the updated script.
+    chrome.runtime.sendMessage({
+      'name': 'UserScriptChanged',
+      'details': userScript.details,
+      'parsedDetails': userScript.parsedDetails,
+    });
+  });
 }
 
 

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -129,7 +129,7 @@ function onEditorSaved(message, sender, sendResponse) {
   userScript.updateFromEditorSaved(message)
       .then(value => saveUserScript(userScript));
 };
-window.onEditorSaved = onEditorSaved;
+window.Message.onEditorSaved = onEditorSaved;
 
 
 function onListUserScripts(message, sender, sendResponse) {
@@ -141,7 +141,7 @@ function onListUserScripts(message, sender, sendResponse) {
   }
   sendResponse(result);
 };
-window.onListUserScripts = onListUserScripts;
+window.Message.onListUserScripts = onListUserScripts;
 
 
 function onUserScriptGet(message, sender, sendResponse) {
@@ -154,7 +154,7 @@ function onUserScriptGet(message, sender, sendResponse) {
     sendResponse(userScripts[message.uuid].details);
   }
 };
-window.onUserScriptGet = onUserScriptGet;
+window.Message.onUserScriptGet = onUserScriptGet;
 
 
 function onApiGetResourceBlob(message, sender, sendResponse) {
@@ -180,7 +180,7 @@ function onApiGetResourceBlob(message, sender, sendResponse) {
     }
   }
 };
-window.onApiGetResourceBlob = onApiGetResourceBlob;
+window.Message.onApiGetResourceBlob = onApiGetResourceBlob;
 
 
 function onUserScriptToggleEnabled(message, sender, sendResponse) {
@@ -191,7 +191,7 @@ function onUserScriptToggleEnabled(message, sender, sendResponse) {
   saveUserScript(userScript);
   sendResponse({'enabled': userScript.enabled});
 };
-window.onUserScriptToggleEnabled = onUserScriptToggleEnabled;
+window.Message.onUserScriptToggleEnabled = onUserScriptToggleEnabled;
 
 
 function onUserScriptUninstall(message, sender, sendResponse) {
@@ -209,7 +209,7 @@ function onUserScriptUninstall(message, sender, sendResponse) {
     };
   });
 };
-window.onUserScriptUninstall = onUserScriptUninstall;
+window.Message.onUserScriptUninstall = onUserScriptUninstall;
 
 
 function saveUserScript(userScript) {

--- a/src/bg/value-store.js
+++ b/src/bg/value-store.js
@@ -60,7 +60,7 @@ function onApiDeleteValue(message, sender, sendResponse) {
   // Return true causes sendResponse to work after async. step above completes.
   return true;
 };
-window.onApiDeleteValue = onApiDeleteValue;
+window.Message.onApiDeleteValue = onApiDeleteValue;
 
 
 function onApiGetValue(message, sender, sendResponse) {
@@ -93,7 +93,7 @@ function onApiGetValue(message, sender, sendResponse) {
   // Return true causes sendResponse to work after async. step above completes.
   return true;
 };
-window.onApiGetValue = onApiGetValue;
+window.Message.onApiGetValue = onApiGetValue;
 
 
 function onApiListValues(message, sender, sendResponse) {
@@ -119,7 +119,7 @@ function onApiListValues(message, sender, sendResponse) {
   // Return true causes sendResponse to work after async. step above completes.
   return true;
 };
-window.onApiListValues = onApiListValues;
+window.Message.onApiListValues = onApiListValues;
 
 
 function onApiSetValue(message, sender, sendResponse) {
@@ -148,6 +148,6 @@ function onApiSetValue(message, sender, sendResponse) {
   // Return true causes sendResponse to work after async. step above completes.
   return true;
 };
-window.onApiSetValue = onApiSetValue;
+window.Message.onApiSetValue = onApiSetValue;
 
 })();

--- a/test/bg/on-message.test.js
+++ b/test/bg/on-message.test.js
@@ -1,0 +1,20 @@
+/* Checks the functionality of on-message */
+
+describe('bg/on-message.js', () => {
+  // Wrap sendMessage so that that tests can look cleaner
+  const sendMessage = (message, cb, remote) => {
+    return () => {
+      return chrome.runtime.sendMessage(message, cb, remote);
+    }
+  };
+
+  it('blocks non API message from unknown sender', () => {
+    let message = {
+      'name': 'UserScriptToggleEnabled',
+    };
+
+    chai.expect(sendMessage(message, null, true), 'Permission denied not thrown')
+      .to.throw('ERROR refusing to handle');
+  });
+});
+

--- a/test/bg/user-script-registry.test.js
+++ b/test/bg/user-script-registry.test.js
@@ -25,7 +25,7 @@ describe('bg/user-script-registry', () => {
     assert.isNotOk(scriptNamed('exponential'));
     UserScriptRegistry._saveUserScript(userScript).then(() => {
       assert.isOk(scriptNamed('exponential'));
-      onUserScriptUninstall({'uuid': userScript.uuid}, null, () => {
+      Message.onUserScriptUninstall({'uuid': userScript.uuid}, null, () => {
         assert.isNotOk(scriptNamed('exponential'));
         done();
       });

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,17 @@
 // user-script-obj.js looks up the extension version from the manifest
 chrome.runtime.getManifest.returns({'version': 1});
+
+// on-message uses getUrl to determine if a message is from an extension page
+chrome.runtime.getURL.withArgs('').returns('gm-ext');
+// all messages should pass through on-message, create a wrapper
+chrome.runtime.sendMessage.callsFake((message, cb, remote) => {
+  // Adds a optional third parameter that determines if the message should
+  // simulate a message from a remote page. The default is to treat the
+  // message as originating from an extension page. This is to prevent erros
+  // in code that is unaware of the third option (e.g. user-script-registry.js)
+  if (remote) {
+    return onMessage(message, {'url': 'fake'}, cb);
+  } else {
+    return onMessage(message, {'url': 'gm-ext'}, cb);
+  }
+});


### PR DESCRIPTION
I was working on #2777 and came to the point where I should implement some tests. I found out that there was no setup for specifically testing `on-message`. As I worked to implement the testing bits I realized that more than minor setup / changes were needed in order to adequately provide the test environment and decided to work on that before going back the original issue.

Commit messages explain the changes pretty well I think.

Of note:
'Safely handle bad userscript save transactions' was cherry-picked into this branch.