### PR TITLE
Avoid crash in setIcon on Firefox for Android

### DIFF
--- a/src/bg/is-enabled.js
+++ b/src/bg/is-enabled.js
@@ -42,9 +42,13 @@ window.onEnabledSet = onEnabledSet;
 
 
 function setIcon() {
-  chrome.browserAction.setIcon({
-    'path': 'skin/icon32' + (isEnabled ? '' : '-disabled') + '.png',
-  });
+  // Firefox for Android does not have setIcon
+  // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction/setIcon#Browser_compatibility
+  if (chrome.browserAction.setIcon) {
+    chrome.browserAction.setIcon({
+      'path': 'skin/icon32' + (isEnabled ? '' : '-disabled') + '.png',
+    });
+  }
 }
 
 


### PR DESCRIPTION
Trying to toggle greasemonkey on or off fails right now on Android due to a missing API. Check for setIcon before we call it.

https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction/setIcon#Browser_compatibility