### PR TITLE
fix XMLHttpRequests that don't have the "async" parameter

### DIFF
--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -9,7 +9,7 @@ reference any other objects from this file.
 // Increment this number when updating `calculateEvalContent()`.  If it
 // is higher than it was when eval content was last calculated, it will
 // be re-calculated.
-const EVAL_CONTENT_VERSION = 7;
+const EVAL_CONTENT_VERSION = 8;
 
 
 // Private implementation.
@@ -25,9 +25,12 @@ const SCRIPT_ENV_EXTRA = `
     construct: (target, argumentsList, newTarget) => {
       let xhr = new origXhr();
       let origOpen = xhr.open;
-      xhr.open = (method_, url_, async_, user_, password_) => {
-        let url = new URL(url_, document.baseURI);
-        return origOpen.apply(xhr, [method_, url.toString(), async_, user_, password_]);
+      xhr.open = function() {
+        if (arguments.length >= 2) {
+          let url = new URL(arguments[1], document.baseURI);
+          arguments[1] = url.toString();
+        }
+        return origOpen.apply(xhr, arguments);
       };
       return xhr;
     },

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -9,7 +9,7 @@ reference any other objects from this file.
 // Increment this number when updating `calculateEvalContent()`.  If it
 // is higher than it was when eval content was last calculated, it will
 // be re-calculated.
-const EVAL_CONTENT_VERSION = 8;
+const EVAL_CONTENT_VERSION = 9;
 
 
 // Private implementation.
@@ -19,23 +19,17 @@ const extensionVersion = chrome.runtime.getManifest().version;
 const aboutBlankRegexp = /^about:blank/;
 
 const SCRIPT_ENV_EXTRA = `
-(() => {
-  let origXhr = XMLHttpRequest;
-  XMLHttpRequest = new Proxy(XMLHttpRequest, {
-    construct: (target, argumentsList, newTarget) => {
-      let xhr = new origXhr();
-      let origOpen = xhr.open;
-      xhr.open = function() {
-        if (arguments.length >= 2) {
-          let url = new URL(arguments[1], document.baseURI);
-          arguments[1] = url.toString();
-        }
-        return origOpen.apply(xhr, arguments);
-      };
-      return xhr;
-    },
-  });
-})();
+{
+  let origOpen = XMLHttpRequest.prototype.open;
+  XMLHttpRequest.prototype.open = function open(method, url) {
+    // only include method and url parameters so the function length is set properly
+    if (arguments.length >= 2) {
+      let newUrl = new URL(arguments[1], document.location.href);
+      arguments[1] = newUrl.toString();
+    }
+    return origOpen.apply(this, arguments);
+  };
+}
 `;
 
 


### PR DESCRIPTION
The #2771 fix has a bug in it. If you don't supply the optional async parameter it defaults to undefined, which evalulates to false. It should default to true if it's not supplied. This fixes the xhr shim.