### PR TITLE
Support downgrading evalContentVersion on scripts

### DIFF
--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -106,7 +106,7 @@ function loadUserScripts() {
       event.target.result.forEach(details => {
         let userScript = new EditableUserScript(details);
         userScripts[details.uuid] = userScript;
-        if (userScript.evalContentVersion < EVAL_CONTENT_VERSION) {
+        if (userScript.evalContentVersion != EVAL_CONTENT_VERSION) {
           userScript.calculateEvalContent();
           saveUserScript(userScript);
         }


### PR DESCRIPTION
Ran into this developing my last patch. Allowing for version downgrades on evalContent should be allowed.