### PR TITLE
Make `UserScriptRegistry._loadUserScripts()` return Promise for tests.

### DIFF
--- a/test/bg/user-script-registry.test.js
+++ b/test/bg/user-script-registry.test.js
@@ -21,7 +21,7 @@ describe('bg/user-script-registry', () => {
     assert.isNotOk(scriptNamed('footnote'));
     await UserScriptRegistry._saveUserScript(userScript);
     assert.isOk(scriptNamed('footnote'));
-    UserScriptRegistry._loadUserScripts();
+    await UserScriptRegistry._loadUserScripts();
     assert.isOk(scriptNamed('footnote'));
   });
 


### PR DESCRIPTION
- `indexedDB.deleteDatabase('greasemonkey')` will be blocked until tests completed because user-script-registry.js leave the database openning.
- Now the second `assert.isOk(scriptNamed('footnote'));` in user-script-registry.test.js will be executed before executing `UserScriptRegistry._loadUserScripts();` is completed.