### PR TITLE
Specify openerTabId for tabs from GM.openInTab.

### DIFF
--- a/src/bg/on-user-script-open-in-tab.js
+++ b/src/bg/on-user-script-open-in-tab.js
@@ -10,5 +10,6 @@ function onApiOpenInTab(message, sender, sendResponse) {
     active: message.active,
     windowId: senderTab.windowId,
     index: senderTab.index + 1, // next to senderTab
+    openerTabId: senderTab.id,
   });
 };


### PR DESCRIPTION
Some addons (for example, [Tree Style Tab](https://addons.mozilla.org/firefox/addon/tree-style-tab/)) refers `openerTabId` of tabs to detect their relation. The parameter is supported by both Google Chrome and Firefox (57+).