### PR TITLE
Separate value-store implementation from messaging

### DIFF
--- a/src/bg/value-store.js
+++ b/src/bg/value-store.js
@@ -35,12 +35,27 @@ function scriptStoreDb(uuid) {
 
 //////////////////////////// Store Implementation \\\\\\\\\\\\\\\\\\\\\\\\\\\\\
 
+function deleteStore(uuid) {
+  return new Promise((resolve, reject) => {
+    let deleteReq = indexedDB.deleteDatabase('user-script-' + uuid);
+    deleteReq.onsuccess = event => {
+      resolve(null);
+    };
+    deleteReq.onerror = event => {
+      reject(event);
+    };
+  });
+}
+
+
 function deleteValue(uuid, key) {
   return scriptStoreDb(uuid).then(db => {
     return new Promise((resolve, reject) => {
       let txn = db.transaction([valueStoreName], 'readwrite');
       let store = txn.objectStore(valueStoreName);
       let req = store.delete(key);
+      db.close();
+
       req.onsuccess = event => {
         resolve(true);
       };
@@ -62,6 +77,8 @@ function getValue(uuid, key) {
       let txn = db.transaction([valueStoreName], 'readonly');
       let store = txn.objectStore(valueStoreName);
       let req = store.get(key);
+      db.close();
+
       req.onsuccess = event => {
         if (!event.target.result) {
           resolve(undefined);
@@ -87,6 +104,8 @@ function listValues(uuid) {
       let txn = db.transaction([valueStoreName], 'readonly');
       let store = txn.objectStore(valueStoreName);
       let req = store.getAllKeys();
+      db.close();
+
       req.onsuccess = event => {
         resolve(req.result);
       };
@@ -108,6 +127,8 @@ function setValue(uuid, key, value) {
       let txn = db.transaction([valueStoreName], 'readwrite');
       let store = txn.objectStore(valueStoreName);
       let req = store.put({'value': value}, key);
+      db.close();
+
       req.onsuccess = event => {
         resolve(true);
       };
@@ -124,6 +145,7 @@ function setValue(uuid, key, value) {
 
 
 window.ValueStore = {
+  'deleteStore': deleteStore,
   'deleteValue': deleteValue,
   'getValue': getValue,
   'listValues': listValues,

--- a/src/bg/value-store.js
+++ b/src/bg/value-store.js
@@ -60,8 +60,7 @@ function deleteValue(uuid, key) {
         resolve(true);
       };
       req.onerror = event => {
-        console.warn(
-          'failed to delete', key, 'for', uuid, ':', event);
+        console.warn('failed to delete', key, 'for', uuid, ':', event);
         // Don't reject to maintain compatibility with code that expects a
         // false return value.
         resolve(false);
@@ -87,8 +86,7 @@ function getValue(uuid, key) {
         }
       };
       req.onerror = event => {
-        console.warn(
-            'failed to retrieve', key, 'for', uuid, ':', event);
+        console.warn('failed to retrieve', key, 'for', uuid, ':', event);
         // Don't reject to maintain compatibility with code that expects a
         // undefined return value.
         resolve(undefined);
@@ -110,8 +108,7 @@ function listValues(uuid) {
         resolve(req.result);
       };
       req.onerror = event => {
-        console.warn(
-            'failed to list stored keys for', uuid, ':', event);
+        console.warn('failed to list stored keys for', uuid, ':', event);
         // Don't reject to maintain compatibility with code that expects a
         // undefined return value.
         resolve(undefined);
@@ -133,8 +130,7 @@ function setValue(uuid, key, value) {
         resolve(true);
       };
       req.onerror = event => {
-        console.warn(
-            'failed to set', key, 'for', uuid, ':', event);
+        console.warn('failed to set', key, 'for', uuid, ':', event);
         // Don't reject to maintain compatibility with code that expects a
         // false return value.
         resolve(false);

--- a/test/bg/value-store.test.js
+++ b/test/bg/value-store.test.js
@@ -1,0 +1,57 @@
+describe('bg/value-store', () => {
+  let storeName = 'gmTests';
+
+  function cleanup() { return ValueStore.deleteStore(storeName); }
+  beforeEach(cleanup);
+  // Cleanup the stores one more time.
+  after(cleanup);
+
+  it('can set and retrieve a value', () => {
+    let testKey = 'gmFoo';
+    let testValue = 'gmValue';
+
+    return ValueStore.setValue(storeName, testKey, testValue)
+        .then(isSet => {
+          assert.equal(isSet, true, 'Failed to set value');
+          return ValueStore.getValue(storeName, testKey);
+        }).then(value => {
+          assert.equal(value, testValue, 'Failed to get value');
+        });
+  });
+
+  it('can delete a value', () => {
+    let testKey = 'gmBar';
+    let testValue = 'gmValue';
+
+    return ValueStore.setValue(storeName, testKey, testValue)
+        .then(isSet => {
+          assert.equal(isSet, true, 'Failed to set value');
+          return ValueStore.deleteValue(storeName, testKey);
+        }).then(isDeleted => {
+          assert.equal(isDeleted, true, 'Failed to delete value');
+          return ValueStore.getValue(storeName, testKey);
+        }).then(value => {
+          assert.isUndefined(value, 'Value has a result, was not deleted');
+        });
+  });
+
+  it('can list all keys', () => {
+    let testKeys = ['gmBaz1', 'gmBaz2', 'gmBaz3'];
+    let testValue = 'gmValue';
+    let setPromises = [
+      ValueStore.setValue(storeName, testKeys[0], testValue),
+      ValueStore.setValue(storeName, testKeys[1], testValue),
+      ValueStore.setValue(storeName, testKeys[2], testValue),
+    ];
+
+    return Promise.all(setPromises)
+        .then(isSets => {
+          expect(isSets, 'Failed to set values')
+              .to.have.members([true, true, true]);
+          return ValueStore.listValues(storeName);
+        }).then(storeKeys => {
+          expect(storeKeys, 'Listed keys do not match provided keys')
+              .to.have.members(testKeys);
+        });
+  });
+});


### PR DESCRIPTION
Unlink value-store functions from the messaging interface so that
they can be called directly from the background script, should the
need arise.

Useful for tests and for #2747 