### PR TITLE
Add import userscript from file

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,7 @@
   "Greasemonkey is active": { "message": "Greasemonkey is active" },
   "Greasemonkey is disabled": { "message": "Greasemonkey is disabled" },
   "Ignoring @match pattern $1 because:\n$2": { "message": "Ignoring @match pattern $1 because:\n$2" },
+  "Invalid $1 URL ($2).\nScript missing `@downloadUrl`?": { "message": "Invalid $1 URL ($2).\nScript missing `@downloadUrl`?"},
   "Install": { "message": "Install" },
   "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge.": { "message": "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge." },
   "Matches:": { "message": "Matches:" },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -23,6 +23,7 @@
   "Greasemonkey is active": { "message": "Greasemonkey is active" },
   "Greasemonkey is disabled": { "message": "Greasemonkey is disabled" },
   "Ignoring @match pattern $1 because:\n$2": { "message": "Ignoring @match pattern $1 because:\n$2" },
+  "Import Failure": { "message": "Import Failure" },
   "Invalid $1 URL ($2).\nScript missing `@downloadUrl`?": { "message": "Invalid $1 URL ($2).\nScript missing `@downloadUrl`?"},
   "Install": { "message": "Install" },
   "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge.": { "message": "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge." },

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -18,6 +18,7 @@
   "GM.xmlHttpRequest: Passed URL has bad protocol: $1": { "message": "GM.xmlHttpRequest: Passed URL has bad protocol: $1" },
   "GM.xmlHttpRequest: Received no URL.": { "message": "GM.xmlHttpRequest: Received no URL." },
   "GM.xmlHttpRequest: Received no details.": { "message": "GM.xmlHttpRequest: Received no details." },
+  "Greasemonkey Import Script From File": { "message": "Greasemonkey Import Script From File" },
   "Greasemonkey Wiki": { "message": "Greasemonkey Wiki" },
   "Greasemonkey home page": { "message": "Greasemonkey home page" },
   "Greasemonkey is active": { "message": "Greasemonkey is active" },
@@ -32,8 +33,10 @@
   "Requires special APIs:": { "message": "Requires special APIs:" },
   "Runs on:": { "message": "Runs on:" },
   "This is a Greasemonkey user script.  Click install to start using it.": { "message": "This is a Greasemonkey user script.  Click install to start using it." },
+  "This page is used to import a userscript from a file. Unfortunately, for the time (until Mozilla fixes a particular bug) this needs to be done in a separate tab and cannot be done through the Monkey Menu.": { "message": "This page is used to import a userscript from a file. Unfortunately, for the time (until Mozilla fixes a particular bug) this needs to be done in a separate tab and cannot be done through the Monkey Menu." },
   "Undo uninstall": { "message": "Undo uninstall" },
   "Uninstall": { "message": "Uninstall" },
+  "Add a script to the database.": { "message": "Add a script to the database." },
   "User scripts for this tab": { "message": "User scripts for this tab" },
   "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." }
 }

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -11,6 +11,7 @@ module.exports = function(config) {
       './src/**/*.run.js',
       './src/content/edit-user-script.js',  // CodeMirror dependency.
       './src/content/install-dialog.js',  // Not ready for testing yet.  TODO!
+      './src/content/import/*',         // DB Imports
       './src/util/rivets-formatters.js',
     ],
     frameworks: ['chai', 'mocha', 'sinon', 'sinon-chrome'],

--- a/manifest.json
+++ b/manifest.json
@@ -42,6 +42,7 @@
       "src/bg/value-store.js",
       "src/parse-meta-line.js",
       "src/parse-user-script.js",
+      "src/parse-user-script-errors.js",
       "src/user-script-obj.js",
       "src/util/check-api-call-allowed.js",
       "third-party/MatchPattern.js",

--- a/src/bg/user-script-install.js
+++ b/src/bg/user-script-install.js
@@ -2,7 +2,7 @@
 (function() {
 
 /// Receive a UserScriptInstall message.
-window.onUserScriptInstall = async function(message, sender) {
+window.onUserScriptInstall = function(message, sender) {
   if (message.details) {
     let downloader = new Downloader(message.details, sender);
     downloader.start(function() {
@@ -11,7 +11,20 @@ window.onUserScriptInstall = async function(message, sender) {
       }
     });
   } else if (message.source) {
-    return await UserScriptRegistry.installFromSource(message.source);
+    // Returning a promise
+    return UserScriptRegistry.installFromSource(message.source)
+        .catch(err => {
+          if (err instanceof ParseError) {
+            console.warn(err);
+            chrome.notifications.create({
+              'type': 'basic',
+              'title': 'Failed to import script',
+              'message': err.message,
+            });
+          }
+          // Propagate to the message listener
+          throw err;
+        });
   }
 }
 

--- a/src/bg/user-script-install.js
+++ b/src/bg/user-script-install.js
@@ -18,7 +18,7 @@ window.onUserScriptInstall = function(message, sender) {
             console.warn(err);
             chrome.notifications.create({
               'type': 'basic',
-              'title': 'Failed to import script',
+              'title': _('Import Failure'),
               'message': err.message,
             });
           }

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -93,7 +93,12 @@ async function installFromSource(source) {
           console.error('Error looking up script!', event);
         };
       } catch (e) {
-        console.error('at installFromSource(), db fail:', e);
+        if (e instanceof ParseError) {
+          // Noop, will be handled by caller
+        } else {
+          console.error('at installFromSource(), db fail:', e);
+        }
+        reject(e);
       }
     });
   });

--- a/src/browser/monkey-menu.css
+++ b/src/browser/monkey-menu.css
@@ -155,6 +155,7 @@ section {
   min-height: 24px;
   padding: 4px 12px 4px 7px;
   width: 100%;
+  overflow-y: hidden;
 }
 
 .subview-item.heading {
@@ -199,6 +200,14 @@ section {
   overflow-x: hidden;
   padding-left: 3px;
   text-overflow: ellipsis;
+}
+
+.subview-item .input {
+  left: 0;
+  margin-top: -9px;
+  opacity: 0;
+  position: absolute;
+  width: 100%;
 }
 
 .subview-item::after {

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -64,6 +64,12 @@
       <div class="text">{'New user script ...'|i18n}</div>
     </a>
 
+    <a href="#import-user-script" class="subview-item input-item">
+      <div class="icon fa fa-file-text-o"></div>
+      <div class="text">Import user script ...</div>
+      <input class="input" id="import-script-file" type="file" title=" " />
+    </a>
+
     <hr>
 
     <a href="#https://www.greasespot.net/"

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -135,6 +135,7 @@
 <script src="/src/util/rivets-formatters.js"></script>
 <script src="/src/parse-meta-line.js"></script>
 <script src="/src/parse-user-script.js"></script>
+<script src="/src/parse-user-script-errors.js"></script>
 <script src="/src/user-script-obj.js"></script>
 <script src="monkey-menu.js"></script>
 <script src="monkey-menu.run.js"></script>

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -66,7 +66,7 @@
 
     <a href="#import-user-script" class="subview-item input-item">
       <div class="icon fa fa-file-text-o"></div>
-      <div class="text">Import user script ...</div>
+      <div class="text">{'Import user script ...'|i18n}</div>
       <input class="input" id="import-script-file" type="file" title=" " />
     </a>
 

--- a/src/content/edit-user-script.html
+++ b/src/content/edit-user-script.html
@@ -26,7 +26,8 @@
 <script src="/third-party/codemirror/addon/lint/lint.js"></script>
 <link rel="stylesheet" href="/third-party/codemirror/addon/lint/lint.css">
 <script src="../parse-meta-line.js"></script>
-<script src="../parse-user-script.js"></script>
+<script src="/src/parse-user-script.js"></script>
+<script src="/src/parse-user-script-errors.js"></script>
 <script src="./cm-addons/lint-metadata.js"></script>
 <script src="./cm-addons/lint-metadata.run.js"></script>
 </head>

--- a/src/content/import/import-script.html
+++ b/src/content/import/import-script.html
@@ -20,20 +20,18 @@
 <div id="content">
 
 
-<h2 class="header">Greasemonkey Import Script From File</h2>
+<h2 class="header">{'Greasemonkey Import Script From File'|i18n}</h2>
 <div class="body">
   <div class="details">
     <p>
-This page is used to import a userscript from a file. Unfortunately, for the
-time (until Mozilla fixes a particular bug) this needs to be done in a
-separate tab and cannot be done through the Monkey Menu.
+{'This page is used to import a userscript from a file. Unfortunately, for the time (until Mozilla fixes a particular bug) this needs to be done in a separate tab and cannot be done through the Monkey Menu.'|i18n}
     </p>
   </div>
 
   <div class="import-option">
-    <h4>User Script</h4>
+    <h4>{'Install'|i18n}</h4>
     <div class="details">
-Add a script to the database.
+{'Add a script to the database.'|i18n}
     </div>
     <input class="input-item" id="import-script-file" type="file" />
   </div>
@@ -41,4 +39,7 @@ Add a script to the database.
 
 
 </div>
+
+<script src="/third-party/rivets/rivets.bundled.min.js"></script>
+<script src="/src/util/rivets-formatters.js"></script>
 </body>

--- a/src/content/import/import-script.html
+++ b/src/content/import/import-script.html
@@ -1,0 +1,44 @@
+<!DOCTYPE html>
+<!--
+  This /should/ be temporary until Mozilla fixes their stuff.
+  Bugzilla:
+  "Keep autoclose popups opened when opening a modal file picker dialog"
+  https://bugzilla.mozilla.org/show_bug.cgi?id=1366330
+-->
+
+<html>
+<head>
+<meta charset="utf-8">
+
+<link rel="stylesheet" href="import.css">
+<script src="import-script.js"></script>
+
+</head>
+
+
+<body>
+<div id="content">
+
+
+<h2 class="header">Greasemonkey Import Script From File</h2>
+<div class="body">
+  <div class="details">
+    <p>
+This page is used to import a userscript from a file. Unfortunately, for the
+time (until Mozilla fixes a particular bug) this needs to be done in a
+separate tab and cannot be done through the Monkey Menu.
+    </p>
+  </div>
+
+  <div class="import-option">
+    <h4>User Script</h4>
+    <div class="details">
+Add a script to the database.
+    </div>
+    <input class="input-item" id="import-script-file" type="file" />
+  </div>
+</div>
+
+
+</div>
+</body>

--- a/src/content/import/import-script.js
+++ b/src/content/import/import-script.js
@@ -1,0 +1,38 @@
+
+function onLoad(event) {
+  document.getElementById('import-script-file')
+      .addEventListener('change', onImportUserScript);
+}
+
+
+function onImportUserScript(event) {
+  let importScript = event.target;
+  let fr = new FileReader();
+
+  fr.onload = () => {
+    if (2 === fr.readyState) {
+      // Done loading
+      chrome.runtime.sendMessage(
+          {'name': 'UserScriptInstall', 'source': fr.result},
+          uuid => openUserScriptEditor(uuid));
+    }
+  };
+  fr.readAsText(importScript.files[0]);
+}
+
+
+// Copy paste from monkey menu for convenience
+function openUserScriptEditor(scriptUuid) {
+  chrome.tabs.create({
+    'active': true,
+    'url':
+        chrome.runtime.getURL('src/content/edit-user-script.html')
+        + '#' + scriptUuid,
+  });
+  chrome.tabs.getCurrent(curTab => {
+    chrome.tabs.remove(curTab.id);
+  });
+}
+
+
+document.addEventListener('DOMContentLoaded', onLoad);

--- a/src/content/import/import-script.js
+++ b/src/content/import/import-script.js
@@ -14,7 +14,12 @@ function onImportUserScript(event) {
       // Done loading
       chrome.runtime.sendMessage(
           {'name': 'UserScriptInstall', 'source': fr.result},
-          uuid => openUserScriptEditor(uuid));
+          uuid => {
+            // TODO: When switching to promises use `.catch`
+            if (!chrome.runtime.lastError) {
+              openUserScriptEditor(uuid);
+            }
+          });
     }
   };
   fr.readAsText(importScript.files[0]);

--- a/src/content/import/import-script.js
+++ b/src/content/import/import-script.js
@@ -1,5 +1,7 @@
 
 function onLoad(event) {
+  rivets.bind(document);
+
   document.getElementById('import-script-file')
       .addEventListener('change', onImportUserScript);
 }

--- a/src/content/import/import.css
+++ b/src/content/import/import.css
@@ -1,0 +1,13 @@
+body { font-family: sans; }
+#content {
+  border: 1px solid lightgray;
+  margin: 125px auto 0;
+  padding: 12px;
+  width: 62%;
+}
+h2.header { border-bottom: 1px solid; margin: 10px auto 20px; }
+.details { padding: 0 25px; }
+.import-option { margin-top: 10px; }
+.import-option h4 { margin-bottom: 7px; }
+.important { color: red; font-weight: bold; }
+.input-item { margin-top: 7px; }

--- a/src/parse-user-script-errors.js
+++ b/src/parse-user-script-errors.js
@@ -1,0 +1,15 @@
+/* Custom errors for specific problems that occur during parse-user-script */
+
+// Base class. Should not be instantiated
+class ParseError extends Error {
+  constructor(msg) { super(msg); }
+}
+
+
+// Error thrown if duplicate resource names are found
+class DuplicateResourceError extends ParseError {
+  constructor(msg) {
+    super(msg);
+    this.name = 'DuplicateResourceError';
+  }
+}

--- a/src/parse-user-script-errors.js
+++ b/src/parse-user-script-errors.js
@@ -13,3 +13,16 @@ class DuplicateResourceError extends ParseError {
     this.name = 'DuplicateResourceError';
   }
 }
+
+
+// Error to throw if relative resources are found without a valid downloadUrl
+class InvalidRemoteUrl extends ParseError {
+  constructor(resourceType, url) {
+    super(
+        _('Invalid $1 URL ($2).\nScript missing `@downloadUrl`?',
+          resourceType,
+          url)
+    );
+    this.name = 'InvalidRemoteUrl';
+  }
+}

--- a/src/parse-user-script.js
+++ b/src/parse-user-script.js
@@ -128,7 +128,8 @@ window.parseUserScript = function(content, url, failIfMissing) {
       let resourceName = data.value1;
       let resourceUrl = data.value2;
       if (resourceName in details.resourceUrls) {
-        throw new Error(_('Duplicate resource name: $1', resourceName));
+        throw new DuplicateResourceError(
+            _('Duplicate resource name: $1', resourceName));
       }
       details.resourceUrls[resourceName] = safeURL(resourceUrl, url).toString();
       break;


### PR DESCRIPTION
Addresses #2612.

Not as nice as being able to navigate to the file but the the baseline result is the same. Unfortunately due to Mozilla issues with the panel a new tab has to be opened. When the relevant bug is fixed the import code should be copy/pastable directly into the Monkey Menu (necessary elements are in place).

I also have another branch that deals with import/export of the entire database, but that's somewhat reliant on the value-store PR (well, it could be done without the PR, but it makes things a bit simpler).