### PR TITLE
Adjust Monkey Menu to look and behave like native FF

### DIFF
--- a/src/browser/monkey-menu.css
+++ b/src/browser/monkey-menu.css
@@ -102,11 +102,9 @@ section {
 }
 
 .subview-back {
-  -moz-context-properties: fill;
   box-sizing: content-box;
   color: inherit;
   display: -moz-box;
-  fill: -moz-fieldText;
   height: 16px;
   margin-right: 4px;
   padding: 8px;
@@ -114,7 +112,7 @@ section {
 }
 
 .subview-back::before {
-  content: url(chrome://browser/skin/arrow-left.svg);
+  content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16"><path fill="rgb(51,51,51)" d="M6.414 8l4.293-4.293a1 1 0 0 0-1.414-1.414l-5 5a1 1 0 0 0 0 1.414l5 5a1 1 0 0 0 1.414-1.414z"/></svg>');
   display: -moz-box;
 }
 
@@ -205,9 +203,6 @@ section {
 }
 
 .subview-item.next-menu::after {
-  -moz-context-properties: fill;
-  color: -moz-fieldText;
-  content: url(chrome://browser/skin/back-12.svg);
-  fill: GrayText;
+  content: url('data:image/svg+xml;utf8,<svg xmlns="http://www.w3.org/2000/svg" width="12" height="12" viewBox="0 0 12 12"><path fill="rgb(111,111,111)" d="M 4.748 6 L 7.966 2.781 C 8.367 2.365 8.169 1.672 7.609 1.532 C 7.358 1.47 7.092 1.54 6.906 1.72 L 3.158 5.47 C 2.865 5.762 2.865 6.237 3.158 6.53 L 6.906 10.279 C 7.321 10.68 8.015 10.481 8.155 9.921 C 8.217 9.67 8.146 9.405 7.966 9.219 Z"/></svg>');
   transform: scaleX(-1) translateY(2px);
 }

--- a/src/browser/monkey-menu.css
+++ b/src/browser/monkey-menu.css
@@ -1,88 +1,213 @@
+:root {
+  --arrowpanel-dimmed: hsla(0, 0%, 80%, 0.3);
+  --panel-separator-color: ThreeDShadow;
+  --panelui-subview-transition-duration: 150ms;
+}
+
 body {
   cursor: default;
   font: caption;
+  max-height: 734px;
+  max-width: 22.35em;
+  min-width: 22.35em;
+  overflow: visible;
   overflow-x: hidden;
-  min-width: 23em;
+  transition: height var(--panelui-subview-transition-duration);
+  will-change: transform;
+
+  display: flex;
+
 }
 body.rendering { display: none; }
 
-body #user-script-detail, body.detail #menu { display: none; }
-body #menu, body.detail #user-script-detail { display: block; }
-#templates { display: none; }
-
-
-section a {
-  color: inherit;
-  cursor: default;
-}
-section a:hover {
-  color: inherit;
-  text-decoration: none;
+/* Depth = 1 Cascading Menu
+ * The below styles (along with a simple JS listener) are used to create a
+ * sliding menu effect. To create a top level menu (depth = 1) the below style
+ * structure can be copied. Further down incudes explaination on how to create
+ * a nested cascading menu (depth > 1).
+ */
+body #menu {
+  transition-duration: 0.25s;
+  transition-property: margin;
 }
 
-.menu-item {
+body.detail #menu {
+  margin-left: -22.35em;
+}
+
+body #user-script-detail {
+  visibility: hidden;
+  transition-duration: 0.25s;
+  transition-property: visibility;
+}
+
+body.detail #user-script-detail {
+  visibility: visible;
+}
+
+/* Depth > 1 Cascading Menu
+ *
+ * For the below example let us assume we have a section with id
+ * '#user-script-config' and it is displayed by applying the class '.config'
+ * on the body element. Furthermore, this section is accessed from the
+ * '#user-script-detail' menu.
+ *
+ * Note: It is assumed that the HTML follows all <section> tags belong to
+ * the same parent node.
+ *
+ * Firstly, add the margin transition on the direct parent menu.
+body #user-script-detail {
+  transition-duration: 0.25s, 0.25s;
+  transition-property: visibility, margin;
+}
+ *
+ * Then, for the specific body class, apply a negative margin to all parent
+ * menus (including the TOP menu).
+body.config #menu,
+body.config #user-script-detail {
+  margin-left: -22.35em;
+}
+ *
+ * Set the default visibility and transition effect on the new menu section.
+body #user-script-config {
+  visibility: hidden;
+  transition-duration: 0.25s;
+  transition-property: visibility;
+}
+ *
+ * Apply visibility to the new menu, and parent menus (not the TOP menu) when
+ * the body is set to the new class.
+body.config #user-script-detail,
+body.config #user-script-config {
+  visibility: visible;
+}
+ *
+ * In the JS code, when the body class is applied it should be noted that the
+ * new menu needs its display set to 'block'. Check the '#user-script-detail'
+ * section for example.
+ */
+
+section {
+  max-width: 22.35em;
+  min-width: 22.35em;
+}
+
+.subview-header {
+  align-items: center;
+  border-bottom: 1px solid var(--panel-separator-color);
   display: flex;
-  flex-direction: row;
-  padding: 4px 8px;
-  -moz-user-select: none;
+  flex: 1 auto;
+  height: 40px;
+  padding: 4px;
 }
-.menu-item * {
-  vertical-align: middle;
-}
-.menu-item .icon {
+
+.subview-back {
+  -moz-context-properties: fill;
+  box-sizing: content-box;
+  color: inherit;
+  display: -moz-box;
+  fill: -moz-fieldText;
+  height: 16px;
   margin-right: 4px;
+  padding: 8px;
+  width: 16px;
 }
-.menu-item .icon img {
-  max-height: 1em;
-  max-width: 1em;
+
+.subview-back::before {
+  content: url(chrome://browser/skin/arrow-left.svg);
+  display: -moz-box;
 }
-.menu-item.disabled {
-  color: #999;
-}
-.menu-item.disabled .icon img {
-  opacity: 0.66;
-}
-.menu-item .text {
-  flex-grow: 1;
+
+.subview-title {
+  color: -moz-fieldText;
+  margin-right: 24px;
+  overflow-x: hidden;
+  text-align: center;
+  text-overflow: ellipsis;
   white-space: nowrap;
-  width: 0;
+  width: 100%;
 }
-.menu-item.heading {
+
+.subview-body {
+  padding: 6px 0;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.subview-body hr {
+  border-top: 1px solid var(--panel-separator-color);
+  margin: 6px 0;
+  min-height: 0;
+}
+
+.subview-item {
+  -moz-box-align: center;
+  background-color: transparent;
+  color: -moz-fieldText;
+  cursor: default;
+  display: -moz-box;
+  max-height: 24px;
+  min-height: 24px;
+  padding: 4px 12px 4px 7px;
+  width: 100%;
+}
+
+.subview-item.heading {
   color: #333;
   font-style: italic;
   padding-left: 21px;
 }
-.menu-item.heading:hover {
-  background: inherit;
-}
-.menu-item:hover, .menu-item:focus {
-  background: #EEE;
+
+.subview-item.disabled {
+  color: #999;
 }
 
-hr {
-  margin: 4px 0;
+.subview-back:hover,
+.subview-back:focus,
+.subview-item:hover,
+.subview-item:focus {
+  background-color: var(--arrowpanel-dimmed);
+  color: inherit;
+  text-decoration: none;
 }
 
+.subview-item .icon {
+  -moz-box-pack: center;
+  display: -moz-box;
+  font-size: 14px;
+  margin-inline-end: 5px;
+  max-width: 21px;
+  min-width: 21px;
+}
 
-header {
-  display: flex;
-  flex-direction: row;
+.subview-item .icon img {
+  max-height: 17px;
+  max-width: 21px;
+  min-width: 21px;
 }
-header * {
-  display: inline-block !important;
-  padding: 6px;
-  vertical-align: middle;
+
+.subview-item.disabled .icon {
+  opacity: 0.7;
 }
-header #back {
-  padding: 8px 6px 4px 6px;
+
+.subview-item .text {
+  -moz-box-flex: 1;
+  display: -moz-box;
+  overflow-x: hidden;
+  text-overflow: ellipsis;
 }
-header #back:hover, header #back:focus {
-  background: #EEE;
+
+.subview-item::after {
+  margin-inline-start: 10px;
+  content: attr(after);
+  float: right;
+  color: GrayText;
 }
-header #name {
-  display: inline-block;
-  flex-grow: 1;
-  text-align: center;
-  white-space: nowrap;
-  width: 0;
+
+.subview-item.next-menu::after {
+  -moz-context-properties: fill;
+  color: -moz-fieldText;
+  content: url(chrome://browser/skin/back-12.svg);
+  fill: GrayText;
+  transform: scaleX(-1) translateY(2px);
 }

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -9,119 +9,113 @@
 </head>
 <body class="rendering">
 
-<section id="menu">
-  <a href="#toggle-global" class="menu-item" id="toggle-global-enabled">
-    <div rv-show="enabled" class="icon fa fa-fw fa-check-circle-o"></div>
-    <div rv-hide="enabled" class="icon fa fa-fw fa-circle-o"></div>
-    <div class="text">Greasemonkey is {enabled | active}</div>
-  </a>
-  <!-- TODO: This feature.
-  <div class="menu-item" id="open-options">
-    <div class="icon fa fa-fw fa-cogs"></div>
-    <div class="text">Greasemonkey Options</div>
-  </div>
-  -->
+<section id="menu" class="subview">
+  <div class="subview-body">
+    <a href="#toggle-global" class="subview-item">
+      <div rv-show="enabled" class="icon fa fa-check-circle-o"></div>
+      <div rv-hide="enabled" class="icon fa fa-circle-o"></div>
+      <div class="text">Greasemonkey is {enabled | active}</div>
+    </a>
+    <!-- TODO: This feature.
+    <div class="subview-item" id="open-options">
+      <div class="icon fa fa-fw fa-cogs"></div>
+      <div class="text">Greasemonkey Options</div>
+    </div>
+    -->
 
-  <div rv-hide="userScripts.active | empty">
-    <hr>
-    <div class="menu-item heading">
-      <div class="text">User scripts for this tab</div>
+    <div rv-hide="userScripts.active | empty">
+      <hr>
+      <div class="subview-item heading">
+        <div class="text">User scripts for this tab</div>
+      </div>
+
+      <a class="subview-item next-menu user-script"
+          rv-each-script="userScripts.active"
+          rv-href="script.uuid | mmUuidMenu"
+          rv-data-uuid="script.uuid"
+          rv-class-disabled="script.enabled | not">
+        <div class="icon"><img rv-src="script.icon"></div>
+        <div class="text">{script.name}</div>
+      </a>
     </div>
 
-    <a rv-each-script="userScripts.active"
-        rv-href="script.uuid | mmUuidMenu"
-        rv-data-uuid="script.uuid"
-        rv-class-disabled="script.enabled | not"
-        class="menu-item user-script">
-      <div class="icon fa-fw"><img rv-src="script.icon"></div>
-      <div class="text">{script.name}</div>
-    </a>
-  </div>
+    <div rv-hide="userScripts.inactive | empty">
+      <hr>
+      <div class="subview-item" rv-hide="userScripts.active | empty">
+        <div class="text heading">Other user scripts</div>
+      </div>
 
-  <div rv-hide="userScripts.inactive | empty">
-    <hr>
-    <div class="menu-item" rv-hide="userScripts.active | empty">
-      <div class="text heading">Other user scripts</div>
+      <a class="subview-item next-menu user-script"
+          rv-each-script="userScripts.inactive"
+          rv-href="script.uuid | mmUuidMenu"
+          rv-data-uuid="script.uuid"
+          rv-class-disabled="script.enabled | not">
+        <div class="icon"><img rv-src="script.icon"></div>
+        <div class="text">{script.name}</div>
+      </a>
     </div>
 
-    <a rv-each-script="userScripts.inactive"
-        rv-href="script.uuid | mmUuidMenu"
-        rv-data-uuid="script.uuid"
-        rv-class-disabled="script.enabled | not"
-        class="menu-item user-script">
-      <div class="icon fa-fw"><img rv-src="script.icon"></div>
-      <div class="text">{script.name}</div>
+    <hr>
+
+    <a href="#new-user-script" class="subview-item">
+      <div class="icon fa fa-file-text-o"></div>
+      <div class="text">New user script ...</div>
+    </a>
+
+    <hr>
+
+    <a href="#https://www.greasespot.net/"
+        class="subview-item">
+      <div class="icon fa fa-link"></div>
+      <div class="text">Greasemonkey home page</div>
+    </a>
+
+    <a href="#https://wiki.greasespot.net/"
+        class="subview-item">
+      <div class="icon fa fa-link"></div>
+      <div class="text">Greasemonkey Wiki</div>
+    </a>
+
+    <a href="#https://wiki.greasespot.net/User_Script_Hosting"
+        class="subview-item">
+      <div class="icon fa fa-link"></div>
+      <div class="text">Get User Scripts</div>
     </a>
   </div>
-
-  <hr>
-
-  <a href="#new-user-script"
-      class="menu-item">
-    <div class="icon fa fa-fw fa-file-text-o"></div>
-    <div class="text">New user script ...</div>
-  </a>
-
-  <hr>
-
-  <a href="#https://www.greasespot.net/"
-      class="menu-item">
-    <div class="icon fa fa-fw fa-link"></div>
-    <div class="text">Greasemonkey home page</div>
-  </a>
-
-  <a href="#https://wiki.greasespot.net/"
-      class="menu-item">
-    <div class="icon fa fa-fw fa-link"></div>
-    <div class="text">Greasemonkey Wiki</div>
-  </a>
-
-  <a href="#https://wiki.greasespot.net/User_Script_Hosting"
-      class="menu-item">
-    <div class="icon fa fa-fw fa-link"></div>
-    <div class="text">Get User Scripts</div>
-  </a>
 </section>
 
 
-<section id="user-script-detail">
-  <header>
-    <a href="#menu-top" class="fa fa-lg fa-chevron-left" id="back"></a>
-    <div id="name">{activeScript.name}</div>
+<section id="user-script-detail" class="subview">
+  <header class="subview-header">
+    <a href="#menu-top" class="subview-back"></a>
+    <div class="subview-title">{activeScript.name}</div>
   </header>
-  <hr>
 
-  <a href="#toggle-user-script"
-      class="menu-item"
-      id="user-script-toggle-enabled">
-    <div class="icon fa fa-fw"
-      rv-class-fa-check-circle-o="activeScript.enabled"
-      rv-class-fa-circle-o="activeScript.enabled | not"
-    ></div>
-    <div class="text">{activeScript.enabled | enabled}</div>
-  </a>
+  <div class="subview-body">
+    <a href="#toggle-user-script" class="subview-item">
+      <div class="icon fa"
+          rv-class-fa-check-circle-o="activeScript.enabled"
+          rv-class-fa-circle-o="activeScript.enabled | not">
+      </div>
+      <div class="text">{activeScript.enabled | enabled}</div>
+    </a>
 
-  <a href="#edit-user-script"
-      class="menu-item"
-      id="user-script-edit">
-    <div class="icon fa fa-fw fa-pencil-square-o"></div>
-    <div class="text">Edit</div>
-  </a>
+    <a href="#edit-user-script" class="subview-item">
+      <div class="icon fa fa-pencil-square-o"></div>
+      <div class="text">Edit</div>
+    </a>
 
-  <a href="#uninstall-user-script"
-      class="menu-item"
-      id="user-script-uninstall"
-      rv-hide="pendingUninstall">
-    <div class="icon fa fa-fw fa-trash-o"></div>
-    <div class="text">Uninstall</div>
-  </a>
-  <a href="#undo-uninstall-user-script"
-      class="menu-item"
-      id="user-script-uninstall-undo"
-      rv-show="pendingUninstall">
-    <div class="icon fa fa-fw fa-trash-o"></div>
-    <div class="text">Undo uninstall ({ pendingUninstall })</div>
-  </a>
+    <a href="#uninstall-user-script" class="subview-item"
+        rv-hide="pendingUninstall">
+      <div class="icon fa fa-trash-o"></div>
+      <div class="text">Uninstall</div>
+    </a>
+    <a href="#undo-uninstall-user-script" class="subview-item"
+        rv-show="pendingUninstall">
+      <div class="icon fa fa-trash-o"></div>
+      <div class="text">Undo uninstall ({ pendingUninstall })</div>
+    </a>
+  </div>
 </section>
 
 

--- a/src/browser/monkey-menu.js
+++ b/src/browser/monkey-menu.js
@@ -120,9 +120,11 @@ function onHashChange(event) {
         gTplData.activeScript.icon = iconUrl(userScript);
         gTplData.activeScript.enabled = userScript.enabled;
         gTplData.activeScript.name = userScript.name;
+        gTplData.activeScript.uuid = userScript.uuid;
 
         gActiveUuid = userScript.uuid;
         document.body.className = 'detail';
+        document.getElementById('user-script-detail').style.display = 'block';
         return;
       }
 
@@ -192,6 +194,19 @@ function onLoad(event) {
           document.body.classList.remove('rendering');
         });
       });
+
+  // Set up listeners for the transition effect. Set display: none when the
+  // vibility property is changed.
+  for (el of document.getElementsByTagName('section')) {
+    if (el.id !== 'menu') {
+      el.style.display = 'none';
+      el.addEventListener('transitionend', event => {
+        if ('visibility' === event.propertyName) {
+          event.target.style.display = 'none';
+        }
+      });
+    }
+  }
 }
 
 


### PR DESCRIPTION
Overhaul the styling to much more closely mimic FF 57 + menu / panel design. Also includes a similar transition effect as seen in native FF menus.

![main_menu](https://user-images.githubusercontent.com/6609453/34925255-d329d9ec-f96d-11e7-8fce-bb1359e267fc.png)


![details_menu](https://user-images.githubusercontent.com/6609453/34925004-3ea0d876-f96c-11e7-9928-d193956cc4e1.png)

