### PR TITLE
Add persistence to GM databases

### DIFF
--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -39,12 +39,7 @@ const db = (function() {
     });
   }
 
-  // Persist is a FF 57+ feature. Conditionally use it.
-  if (navigator.storage && navigator.storage.persist) {
-    return navigator.storage.persist().then(openDb);
-  } else {
-    return openDb();
-  }
+  return navigator.storage.persist().then(openDb);
 })();
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -15,27 +15,36 @@ const dbName = 'greasemonkey';
 const dbVersion = 1;
 const scriptStoreName = 'user-scripts';
 const db = (function() {
-  return new Promise((resolve, reject) => {
-    let dbOpen = indexedDB.open(dbName, dbVersion);
-    dbOpen.onerror = event => {
-      // Note: can get error here if dbVersion is too low.
-      console.error('Error opening user-scripts DB!', event);
-      reject(event);
-    };
-    dbOpen.onsuccess = event => {
-      resolve(event.target.result);
-    };
-    dbOpen.onupgradeneeded = event => {
-      let db = event.target.result;
-      db.onerror = event => {
-        console.error('Error upgrading user-scripts DB!', event);
+  function openDb() {
+    return new Promise((resolve, reject) => {
+      let dbOpen = indexedDB.open(dbName, dbVersion);
+      dbOpen.onerror = event => {
+        // Note: can get error here if dbVersion is too low.
+        console.error('Error opening user-scripts DB!', event);
         reject(event);
       };
-      let store = db.createObjectStore(scriptStoreName, {'keypath': 'uuid'});
-      // The generated from @name and @namespace ID.
-      store.createIndex('id', 'id', {'unique': true});
-    };
-  });
+      dbOpen.onsuccess = event => {
+        resolve(event.target.result);
+      };
+      dbOpen.onupgradeneeded = event => {
+        let db = event.target.result;
+        db.onerror = event => {
+          console.error('Error upgrading user-scripts DB!', event);
+          reject(event);
+        };
+        let store = db.createObjectStore(scriptStoreName, {'keypath': 'uuid'});
+        // The generated from @name and @namespace ID.
+        store.createIndex('id', 'id', {'unique': true});
+      };
+    });
+  }
+
+  // Persist is a FF 57+ feature. Conditionally use it.
+  if (navigator.storage && navigator.storage.persist) {
+    return navigator.storage.persist().then(openDb);
+  } else {
+    return openDb();
+  }
 })();
 
 ///////////////////////////////////////////////////////////////////////////////

--- a/src/bg/value-store.js
+++ b/src/bg/value-store.js
@@ -34,12 +34,7 @@ function scriptStoreDb(uuid) {
     });
   }
 
-  // Persist is a FF 57+ feature. Conditionally use it
-  if (navigator.storage && navigator.storage.persist) {
-    return navigator.storage.persist().then(openDb);
-  } else {
-    return openDb();
-  }
+  return navigator.storage.persist().then(openDb);
 }
 
 //////////////////////////// Store Implementation \\\\\\\\\\\\\\\\\\\\\\\\\\\\\

--- a/test/setup.js
+++ b/test/setup.js
@@ -1,2 +1,6 @@
 // user-script-obj.js looks up the extension version from the manifest
 chrome.runtime.getManifest.returns({'version': 1});
+
+// See comment for details
+// https://github.com/greasemonkey/greasemonkey/pull/2812#issuecomment-358776737
+navigator.storage.persist = () => Promise.resolve(true);


### PR DESCRIPTION
See #2675 for discussions.

Persistent DBs will only be used for FF >= 57. The reason is that the persistent APIs are not supported on older versions. The only way to persist is to use the non-standard `{storage: 'persist'}` option. Unfortunately that option makes migration from 'non-persisted' to 'persisted' very difficult.

See [this comment](https://github.com/greasemonkey/greasemonkey/issues/2675#issuecomment-349675249) for more background information.