### PR TITLE
Include cookies in GM.xhr for same-origin; implement withCredentials for cross-origin

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -57,6 +57,7 @@
   "permissions": [
     "<all_urls>",
     "clipboardWrite",
+    "cookies",
     "notifications",
     "storage",
     "tabs",

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -123,14 +123,14 @@ function open(xhr, d, port, tabUrl) {
   
   // if same-origin XHR, add cookies unless already specified by user
   chrome.cookies.getAll({url: d.url}, cookies => {
-    if (!hasCookieHeader) {
-      if (d.withCredentials || isSameOrigin(tabUrl, d.url)) {        
-          var cookieStrings = [];
-          for (var cookie of cookies) {
-            cookieStrings.push(cookie.name + '=' + cookie.value + ';');
-          }
-          xhr.setRequestHeader(gDummyHeaderPrefix + 'cookie', cookieStrings.join(' '));
-        }
+    if (cookies.length && !hasCookieHeader
+        && (d.withCredentials || isSameOrigin(tabUrl, d.url))
+    ) {
+      var cookieStrings = [];
+      for (var cookie of cookies) {
+        cookieStrings.push(cookie.name + '=' + cookie.value + ';');
+      }
+      xhr.setRequestHeader(gDummyHeaderPrefix + 'cookie', cookieStrings.join(' '));
     }
     
     // if/when we switch from "chrome" to "browser" APIs, set up the promise

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -105,11 +105,11 @@ function open(xhr, d, port, tabUrl) {
   d.responseType && (xhr.responseType = d.responseType);
   d.timeout && (xhr.timeout = d.timeout);
 
-  var hasCookieHeader = false;
+  let hasCookieHeader = false;
   if (d.headers) {
-    for (var prop in d.headers) {
+    for (let prop in d.headers) {
       if (Object.prototype.hasOwnProperty.call(d.headers, prop)) {
-        var propLower = prop.toLowerCase();
+        let propLower = prop.toLowerCase();
         hasCookieHeader = (propLower === 'cookie');
         if (gHeadersToReplace.includes(propLower)) {
           xhr.setRequestHeader(gDummyHeaderPrefix + propLower, d.headers[prop]);
@@ -121,15 +121,14 @@ function open(xhr, d, port, tabUrl) {
     }
   }
   
-  // if same-origin XHR, add cookies unless already specified by user.
-  // if/when we switch from "chrome" to "browser" APIs, set up the promise
-  // so we don't have to query cookies when we know we don't need them.
+  // If this is a same-origin XHR or the user opted in with withCredentials,
+  // add cookies unless already specified by the user.
   chrome.cookies.getAll({url: d.url}, cookies => {
     if (cookies.length && !hasCookieHeader
         && (d.withCredentials || isSameOrigin(tabUrl, d.url))
     ) {
-      var cookieStrings = [];
-      for (var cookie of cookies) {
+      let cookieStrings = [];
+      for (let cookie of cookies) {
         cookieStrings.push(cookie.name + '=' + cookie.value + ';');
       }
       xhr.setRequestHeader(gDummyHeaderPrefix + 'cookie', cookieStrings.join(' '));
@@ -151,12 +150,11 @@ function open(xhr, d, port, tabUrl) {
 
 
 function isSameOrigin(first, second) {
-  var firstUrl, secondUrl;
+  let firstUrl, secondUrl;
   try {
     firstUrl = new URL(first);
     secondUrl = new URL(second);
-  }
-  catch {
+  } catch {
     return false;
   }
   return firstUrl.origin === secondUrl.origin;

--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -121,7 +121,9 @@ function open(xhr, d, port, tabUrl) {
     }
   }
   
-  // if same-origin XHR, add cookies unless already specified by user
+  // if same-origin XHR, add cookies unless already specified by user.
+  // if/when we switch from "chrome" to "browser" APIs, set up the promise
+  // so we don't have to query cookies when we know we don't need them.
   chrome.cookies.getAll({url: d.url}, cookies => {
     if (cookies.length && !hasCookieHeader
         && (d.withCredentials || isSameOrigin(tabUrl, d.url))
@@ -132,9 +134,7 @@ function open(xhr, d, port, tabUrl) {
       }
       xhr.setRequestHeader(gDummyHeaderPrefix + 'cookie', cookieStrings.join(' '));
     }
-    
-    // if/when we switch from "chrome" to "browser" APIs, set up the promise
-    // so this code doesn't have to be nested in the cookie-handling block
+
     var body = d.data || null;
     if (d.binary && (body !== null)) {
       var bodyLength = body.length;


### PR DESCRIPTION
Normally, a background script XHR will only include cookies if third-party cookies are enabled in Firefox. These changes fix that using the `cookies` WebExtension API, giving `GM.xmlHttpRequest` cookie behavior identical to that of a normal XHR. Same-origin requests have cookies included automatically, and cookies can be included for cross-origin requests with the opt-in `withCredentials` parameter.

These changes only take effect if the user has not specifically passed a `Cookier` header to `GM.xmlHttpRequest`. If they do so, those values are sent and no further action is taken. This has the added benefit of allowing the user to opt out of automatic cookies on same-origin requests by manually passing an empty `Cookie` header.

If we don't want the cross-origin/withCredentials stuff, that can be easily removed (just remove `d.withCredentials` from the condition on line 127 of `on-user-script-xhr.js`).

Fixes #2826, I guess.