### PR TITLE
Remove superfluous SPACEs before "..." in the Monkey Menu.

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -19,8 +19,8 @@
         "message": "Aktiviert",
         "description": ""
     },
-    "New user script ...": {
-        "message": "Neues Benutzerskript ...",
+    "New user script...": {
+        "message": "Neues Benutzerskript...",
         "description": ""
     },
     "Install": {

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -26,7 +26,7 @@
   "Install": { "message": "Install" },
   "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge.": { "message": "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge." },
   "Matches:": { "message": "Matches:" },
-  "New user script ...": { "message": "New user script ..." },
+  "New user script...": { "message": "New user script..." },
   "Requires special APIs:": { "message": "Requires special APIs:" },
   "Runs on:": { "message": "Runs on:" },
   "This is a Greasemonkey user script.  Click install to start using it.": { "message": "This is a Greasemonkey user script.  Click install to start using it." },

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -61,7 +61,7 @@
 
     <a href="#new-user-script" class="subview-item">
       <div class="icon fa fa-file-text-o"></div>
-      <div class="text">{'New user script ...'|i18n}</div>
+      <div class="text">{'New user script...'|i18n}</div>
     </a>
 
     <hr>


### PR DESCRIPTION
In accordance with Firefox menus and Greasemonkey 3.x menu.

See https://github.com/greasemonkey/greasemonkey/pull/2770#discussion_r165088332 .