### PR TITLE
Add missing _() function to API scope

### DIFF
--- a/src/bg/api-provider-source.js
+++ b/src/bg/api-provider-source.js
@@ -29,6 +29,8 @@ function apiProviderSource(userScript) {
   let source = '(function() {\n';
   // A private copy of the script UUID which cannot be tampered with.
   source += 'const _uuid = "' + userScript.uuid + '";\n\n';
+  // A private copy of the localization function, used by some of the API functions.
+  source += 'const _ = ' + _.toString() + ';\n\n';
 
   if (grants.includes('GM.deleteValue')) {
     source += 'GM.deleteValue = ' + GM_deleteValue.toString() + ';\n\n';


### PR DESCRIPTION
Several GM.* API functions are using _(...) for localized error messages.
A reference to the function in `src/i18n.js` is missing.
So a private copy of that code had to be imported to the API header.