### PR TITLE
Use a localized name for a new unnamed script (with placeholder $1)

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -138,5 +138,9 @@
     "Does not run on:": {
         "message": "Ausgeschlossen von:",
         "description": ""
+    },
+    "Unnamed Script $1": {
+        "message": "Unbenanntes Skript $1",
+        "description": ""
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -35,5 +35,6 @@
   "User scripts for this tab": { "message": "User scripts for this tab" },
   "User script save failed: script named $1 already exists in namespace $2.": { "message": "User script save failed: script named $1 already exists in namespace $2." },
   "User script save failed: unknown error.": { "message": "User script save failed: unknown error." },
-  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." }
+  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." },
+  "Unnamed Script $1": { "message": "Unnamed Script $1" }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -32,9 +32,9 @@
   "This is a Greasemonkey user script.  Click install to start using it.": { "message": "This is a Greasemonkey user script.  Click install to start using it." },
   "Undo uninstall": { "message": "Undo uninstall" },
   "Uninstall": { "message": "Uninstall" },
+  "Unnamed Script $1": { "message": "Unnamed Script $1" },
   "User scripts for this tab": { "message": "User scripts for this tab" },
   "User script save failed: script named $1 already exists in namespace $2.": { "message": "User script save failed: script named $1 already exists in namespace $2." },
   "User script save failed: unknown error.": { "message": "User script save failed: unknown error." },
-  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." },
-  "Unnamed Script $1": { "message": "Unnamed Script $1" }
+  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." }
 }

--- a/src/browser/monkey-menu.js
+++ b/src/browser/monkey-menu.js
@@ -13,8 +13,11 @@ let gTplData = {
 let gUserScripts = {};
 let gPendingTicker = null;
 
+const gPlaceHolder = '%d';
+const gUnnamedScript = _('Unnamed Script $1', gPlaceHolder);
+
 const gNewScriptTpl = `// ==UserScript==
-// @name     Unnamed Script %d
+// @name     ${gUnnamedScript}
 // @version  1
 // @grant    none
 // ==/UserScript==`;
@@ -79,7 +82,7 @@ function onHashChange(event) {
       break;
     case '#new-user-script':
       let r = Math.floor(Math.random() * 900000 + 100000);
-      let newScriptSrc = gNewScriptTpl.replace('%d', r);
+      let newScriptSrc = gNewScriptTpl.replace(gPlaceHolder, r);
       chrome.runtime.sendMessage(
           {'name': 'UserScriptInstall', 'source': newScriptSrc},
           uuid => openUserScriptEditor(uuid));


### PR DESCRIPTION
A new unnamed script uses `// @name Unnamed script`, followed by a number.
This change makes it possible to use a localized name instead ($1 is the random number).