### PR TITLE
Localized save button, id/version, save error, _() usage, german strings

### DIFF
--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -147,9 +147,19 @@
         "message": "Fehler beim Speichern: Allgemeiner Fehler.",
         "description": ""
     },
-    "$1; Version $2": {
-        "message": "$1; Version $2",
-        "description": ""
+    "$ID$; Version $VERSION$": {
+        "message": "$ID$; Version $VERSION$",
+        "description": "",
+        "placeholders": {
+            "id": {
+                "content": "$1",
+                "example": "namespace/name"
+            },
+            "version": {
+                "content": "$2",
+                "example": "1"
+            }
+        }
     },
     "Save": {
         "message": "Speichern",

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -1,14 +1,14 @@
 {
     "You should only install scripts from sources that you trust.": {
-        "message": "Sie sollten nur Skripte installieren, deren Quelle Sie trauen können.",
+        "message": "Installieren Sie dieses Benutzerskript nur, wenn Sie der Quelle vertrauen.",
         "description": ""
     },
     "Greasemonkey is active": {
-        "message": "Greasemonkey ist aktiv",
+        "message": "Greasemonkey ist aktiviert",
         "description": ""
     },
     "Matches:": {
-        "message": "Muster:",
+        "message": "Ausgeführt auf (@match):",
         "description": ""
     },
     "GM.openInTab: Could not understand the URL: $1": {
@@ -40,7 +40,7 @@
         "description": ""
     },
     "Runs on:": {
-        "message": "Wird aktiviert von:",
+        "message": "Ausgeführt auf:",
         "description": ""
     },
     "Uninstall": {
@@ -76,15 +76,15 @@
         "description": ""
     },
     "User scripts for this tab": {
-        "message": "Benutzerskripte für diese Seite",
+        "message": "Benutzerskripte für diesen Reiter",
         "description": ""
     },
     "GM.xmlHttpRequest: Received no details.": {
-        "message": "GM.xmlHttpRequest: Keine Abfrage-Details übergeben.",
+        "message": "GM.xmlHttpRequest: Keine Anfrage-Details übergeben.",
         "description": ""
     },
     "GM.notification: \"text\" must be a string": {
-        "message": "GM.notification: Parameter \"text\" muss ein String sein",
+        "message": "GM.notification: Parameter \"text\" muss ein String sein.",
         "description": ""
     },
     "Requires special APIs:": {
@@ -120,7 +120,7 @@
         "description": ""
     },
     "Malicious user scripts can violate your privacy, steal your data, and act on your behalf without your knowledge.": {
-        "message": "Bösartige Benutzerskripte könnten Ihre Privatssphäre verletzen, Daten stehlen oder ohne Ihr Wissen in Ihrem Namen handeln.",
+        "message": "Böswillige Benutzerskripte können private Informationen stehlen oder Ihren Computer übernehmen.",
         "description": ""
     },
     "$1 does not @grant method $2": {
@@ -128,7 +128,7 @@
         "description": ""
     },
     "Greasemonkey is disabled": {
-        "message": "Greasemonkey ist inaktiv",
+        "message": "Greasemonkey ist deaktiviert",
         "description": ""
     },
     "This is a Greasemonkey user script.  Click install to start using it.": {
@@ -136,7 +136,7 @@
         "description": ""
     },
     "Does not run on:": {
-        "message": "Ausgeschlossen von:",
+        "message": "Keine Ausführung auf:",
         "description": ""
     },
     "User script save failed: script named $1 already exists in namespace $2.": {

--- a/_locales/de/messages.json
+++ b/_locales/de/messages.json
@@ -138,5 +138,53 @@
     "Does not run on:": {
         "message": "Ausgeschlossen von:",
         "description": ""
+    },
+    "User script save failed: script named $1 already exists in namespace $2.": {
+        "message": "Fehler beim Speichern: Es gibt bereits ein Benutzerskript $1 im Namensbereich $2.",
+        "description": ""
+    },
+    "User script save failed: unknown error.": {
+        "message": "Fehler beim Speichern: Allgemeiner Fehler.",
+        "description": ""
+    },
+    "$1; Version $2": {
+        "message": "$1; Version $2",
+        "description": ""
+    },
+    "Save": {
+        "message": "Speichern",
+        "description": ""
+    },
+    "Script Save Error": {
+        "message": "Fehler beim Speichern des Benutzerskripts",
+        "description": ""
+    },
+    "[Greasemonkey Script $1]": {
+        "message": "[Greasemonkey Benutzerskript $1]",
+        "description": ""
+    },
+    "GM.registerMenuCommand: \"accessKey\" must be a single character": {
+        "message": "GM.registerMenuCommand: \"accessKey\" benötigt ein einzelnes Zeichen",
+        "description": ""
+    },
+    "GM.registerMenuCommand: \"commandFunc\" must be a function": {
+        "message": "GM.registerMenuCommand: \"commandFunc\" muß eine Funktion sein",
+        "description": ""
+    },
+    "User script commands": {
+        "message": "Benutzerbefehle",
+        "description": ""
+    },
+    "User script commands...": {
+        "message": "Benutzerbefehle...",
+        "description": ""
+    },
+    "Download and install errors:": {
+        "message": "Fehler beim Laden und Installieren des Benutzerskripts:",
+        "description": ""
+    },
+    "Script Updated": {
+        "message": "Benutzerskript aktualisiert",
+        "description": ""
     }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,6 +2,7 @@
   "$1 - Greasemonkey User Script Editor": { "message": "$1 - Greasemonkey User Script Editor" },
   "$1 - Greasemonkey User Script": { "message": "$1 - Greasemonkey User Script" },
   "$1 does not @grant method $2": { "message": "$1 does not @grant method $2" },
+  "$1; Version $2": { "message": "$1; Version $2" },
   "Cancel": { "message": "Cancel" },
   "Could not execute user script: $1\n$2": { "message": "Could not execute user script: $1\n$2" },
   "Disabled": { "message": "Disabled" },
@@ -29,11 +30,14 @@
   "New user script...": { "message": "New user script..." },
   "Requires special APIs:": { "message": "Requires special APIs:" },
   "Runs on:": { "message": "Runs on:" },
+  "Save": { "message": "Save" },
+  "Script Save Error": { "message": "Script Save Error" },
   "This is a Greasemonkey user script.  Click install to start using it.": { "message": "This is a Greasemonkey user script.  Click install to start using it." },
   "Undo uninstall": { "message": "Undo uninstall" },
   "Uninstall": { "message": "Uninstall" },
   "User scripts for this tab": { "message": "User scripts for this tab" },
   "User script save failed: script named $1 already exists in namespace $2.": { "message": "User script save failed: script named $1 already exists in namespace $2." },
   "User script save failed: unknown error.": { "message": "User script save failed: unknown error." },
-  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." }
+  "You should only install scripts from sources that you trust.": { "message": "You should only install scripts from sources that you trust." },
+  "[Greasemonkey Script $1]": { "message": "[Greasemonkey Script $1]" }
 }

--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -2,7 +2,7 @@
   "$1 - Greasemonkey User Script Editor": { "message": "$1 - Greasemonkey User Script Editor" },
   "$1 - Greasemonkey User Script": { "message": "$1 - Greasemonkey User Script" },
   "$1 does not @grant method $2": { "message": "$1 does not @grant method $2" },
-  "$1; Version $2": { "message": "$1; Version $2" },
+  "$ID$; Version $VERSION$": { "message": "$ID$; Version $VERSION$", "placeholders": { "id": { "content": "$1", "example": "namespace/name" }, "version": { "content": "$2", "example": "1" }}},
   "Cancel": { "message": "Cancel" },
   "Could not execute user script: $1\n$2": { "message": "Could not execute user script: $1\n$2" },
   "Disabled": { "message": "Disabled" },

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -239,7 +239,7 @@ window.onUserScriptUninstall = onUserScriptUninstall;
 async function saveUserScript(userScript) {
   if (!(userScript instanceof EditableUserScript)) {
     throw new Error(
-        'Cannot save this type of UserScript object:'
+        'Cannot save this type of UserScript object: '
         + userScript.constructor.name);
   }
 
@@ -247,20 +247,18 @@ async function saveUserScript(userScript) {
     let message;
     if (error.name == 'ConstraintError') {
       // Most likely due to namespace / name conflict.
-      message = chrome.i18n.getMessage(
-          'User script save failed: script named $1 already exists in namespace $2.',
-          [JSON.stringify(userScript.name),
-           JSON.stringify(userScript.namespace)]);
+      message = _('User script save failed: script named $1 already exists in namespace $2.',
+                  JSON.stringify(userScript.name),
+                  JSON.stringify(userScript.namespace));
     } else {
-      message = chrome.i18n.getMessage(
-          'User script save failed: unknown error.');
+      message = _('User script save failed: unknown error.');
     }
 
     // TODO: Pass this message to the editor tab, not general notifications.
     let notificationOpts = {
       'iconUrl': '/skin/icon.svg',
       'message': message,
-      'title': 'Script Save Error',
+      'title': _('Script Save Error'),
       'type': 'basic',
     };
     chrome.notifications.create(notificationOpts);

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -247,9 +247,10 @@ async function saveUserScript(userScript) {
     let message;
     if (error.name == 'ConstraintError') {
       // Most likely due to namespace / name conflict.
-      message = _('User script save failed: script named $1 already exists in namespace $2.',
-                  JSON.stringify(userScript.name),
-                  JSON.stringify(userScript.namespace));
+      message = _(
+          'User script save failed: script named $1 already exists in namespace $2.',
+          JSON.stringify(userScript.name),
+          JSON.stringify(userScript.namespace));
     } else {
       message = _('User script save failed: unknown error.');
     }

--- a/src/content/edit-user-script.html
+++ b/src/content/edit-user-script.html
@@ -7,6 +7,8 @@
 <link rel="stylesheet" href="edit-user-script.css">
 
 <script src="/src/i18n.js"></script>
+<script src="/third-party/rivets/rivets.bundled.min.js"></script>
+<script src="/src/util/rivets-formatters.js"></script>
 
 <script src="/third-party/codemirror/codemirror.js"></script>
 <link rel="stylesheet" href="/third-party/codemirror/codemirror.css">
@@ -33,7 +35,7 @@
 
 <body>
 <div class="tab-bar">
-  <div id="save" class="command-item" title="__MSG_Save__">
+  <div id="save" class="command-item" rv-title="'Save'|i18n">
     <i class="icon fa fa-floppy-o"></i>
   </div>
   <ul id="tabs"></ul>

--- a/src/content/edit-user-script.html
+++ b/src/content/edit-user-script.html
@@ -33,7 +33,7 @@
 
 <body>
 <div class="tab-bar">
-  <div id="save" class="command-item" title="Save">
+  <div id="save" class="command-item" title="__MSG_Save__">
     <i class="icon fa fa-floppy-o"></i>
   </div>
   <ul id="tabs"></ul>

--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -1,7 +1,7 @@
 // TODO: Search, replace.
 
-// Change this title as soon as possible, but it won't change later.
-document.getElementById('save').setAttribute('title', _('Save'));
+// Change the title of the save icon (and more) to initial values.
+rivets.bind(document, {});
 
 var editor = CodeMirror(
     document.getElementById('editor'),

--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -43,10 +43,6 @@ chrome.runtime.sendMessage({
   'name': 'UserScriptGet',
   'uuid': userScriptUuid,
 }, userScript => {
-  // Apply as soon as possible, but this label doesn't ever change...
-  //alert(document.getElementById('save').innerHTML); // _('Save');
-  //document.body.getElementById('save').setAttribute('title', _('Save'));
-
   let scriptTab = document.createElement('li');
   scriptTab.className = 'tab active';
   scriptTab.textContent = userScript.name;

--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -1,5 +1,7 @@
 // TODO: Search, replace.
-// TODO: Put name in title.
+
+// Change this title as soon as possible, but it won't change later.
+document.getElementById('save').setAttribute('title', _('Save'));
 
 var editor = CodeMirror(
     document.getElementById('editor'),
@@ -41,6 +43,10 @@ chrome.runtime.sendMessage({
   'name': 'UserScriptGet',
   'uuid': userScriptUuid,
 }, userScript => {
+  // Apply as soon as possible, but this label doesn't ever change...
+  //alert(document.getElementById('save').innerHTML); // _('Save');
+  //document.body.getElementById('save').setAttribute('title', _('Save'));
+
   let scriptTab = document.createElement('li');
   scriptTab.className = 'tab active';
   scriptTab.textContent = userScript.name;

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -173,10 +173,12 @@ window.RemoteUserScript = class RemoteUserScript {
   }
 
   toString() {
-    const fullScriptId = (this.version
-                              ? _('$1; Version $2', this.id, this.version)
-                              : this.id);
-    return _('[Greasemonkey Script $1]', fullScriptId);
+    if (this.version) {
+        const scriptIdAndVersion = _('$1; Version $2', this.id, this.version);
+        return _('[Greasemonkey Script $1]', scriptIdAndVersion);
+    } else {
+        return _('[Greasemonkey Script $1]', this.id);
+    }
   }
 }
 

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -174,7 +174,7 @@ window.RemoteUserScript = class RemoteUserScript {
 
   toString() {
     if (this.version) {
-        const scriptIdAndVersion = _('$1; Version $2', this.id, this.version);
+        const scriptIdAndVersion = _('$ID$; Version $VERSION$', this.id, this.version);
         return _('[Greasemonkey Script $1]', scriptIdAndVersion);
     } else {
         return _('[Greasemonkey Script $1]', this.id);

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -173,9 +173,10 @@ window.RemoteUserScript = class RemoteUserScript {
   }
 
   toString() {
-    return '[Greasemonkey Script ' + this.id
-        + (this.version ? '; ' + this.version : '')
-        + ']';
+    const fullScriptId = (this.version
+                              ? _('$1; Version $2', this.id, this.version)
+                              : this.id);
+    return _('[Greasemonkey Script $1]', fullScriptId);
   }
 }
 


### PR DESCRIPTION
- Save button title is localized just before editor window is created
- User script id and version are formatted localized
- Script Save Error was already mentioned in #2841
- At two locations, the usage of `getMessage` was replaced by `function _()`
- Some new and upcoming german strings were added