### PR TITLE
Remove completion promise from UserScriptDownloader

### DIFF
--- a/src/downloader.js
+++ b/src/downloader.js
@@ -15,10 +15,6 @@ class Downloader {
     this.requireDownloads = {};
     this.resourceDownloads = {};
 
-    this.completion = new Promise((resolve, reject) => {
-      this._completionResolve = resolve;
-      this._completionReject = reject;
-    });
     this.scriptDetails = new Promise((resolve, reject) => {
       this._scriptDetailsResolve = resolve;
       this._scriptDetailsReject = reject;
@@ -158,8 +154,6 @@ class Downloader {
     if (this.iconDownload) await this.iconDownload.result;
     await Promise.all(Object.values(this.requireDownloads).map(d => d.result));
     await Promise.all(Object.values(this.resourceDownloads).map(d => d.result));
-
-    this._completionResolve();
   }
 
   _onProgress(download, event) {
@@ -178,7 +172,6 @@ class Downloader {
         // finish.  If not, errors are fatal.
         if (!download.pending) {
           this._scriptDetailsReject(e);
-          this._completionReject(e);
           return;
         }
       }


### PR DESCRIPTION
It is never used and the automatic promise returned
from `async start()` can be used as a sufficient
replacement.