### PR TITLE
Include MatchPattern properly in the editor

### DIFF
--- a/src/content/edit-user-script.html
+++ b/src/content/edit-user-script.html
@@ -34,6 +34,8 @@
 <script src="/src/parse-meta-line.js"></script>
 <script src="/src/parse-user-script.js"></script>
 <script src="/src/supported-apis.js"></script>
+<script src="/third-party/convert2RegExp.js"></script>
+<script src="/third-party/MatchPattern.js"></script>
 </head>
 
 <body>


### PR DESCRIPTION
Handles #2874 

Missing reference to MatchPattern:
```
Error: Ignoriere @match-Eintrag * aus folgendem Grund:
Error: @match: Could not parse the pattern.  parse-user-script.js:114:15
```