### PR TITLE
Store iconBlob as an array buffer

### DIFF
--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -64,12 +64,14 @@ async function installFromDownloader(userScriptDetails, downloaderDetails) {
       reject(req.error);
     };
   }).then(foundDetails => {
+    foundDetails = foundDetails || {};
+
     if (foundDetails.iconBlob && ! (foundDetails.iconBlob instanceof Blob)) {
       let info = foundDetails.iconBlob;
       foundDetails.iconBlob = new Blob([info.buffer], {'type': info.type});
     }
 
-    let userScript = new EditableUserScript(foundDetails || {});
+    let userScript = new EditableUserScript(foundDetails);
     userScript
         .updateFromDownloaderDetails(userScriptDetails, downloaderDetails);
     return userScript;

--- a/src/user-script-obj.js
+++ b/src/user-script-obj.js
@@ -9,7 +9,7 @@ reference any other objects from this file.
 // Increment this number when updating `calculateEvalContent()`.  If it
 // is higher than it was when eval content was last calculated, it will
 // be re-calculated.
-const EVAL_CONTENT_VERSION = 11;
+const EVAL_CONTENT_VERSION = 12;
 
 
 // Private implementation.


### PR DESCRIPTION
fixes #2908 

There's a very minor bug with this PR that I can't seem to fix. On startup the scripts are force re-saved (updated eval content version) in order to save the buffer into the database. However, on this initial load the icons break and become Firefox placeholders. Reloading Greasemonkey resolves the issue. Further, the issue does **not** occur if you force re-save (update eval content version) again (for future updates).

Perhaps someone else can figure out the above bug. But since it occurs once I don't think it's that big of a deal.