### PR TITLE
Concatenate description meta lines

### DIFF
--- a/src/parse-user-script.js
+++ b/src/parse-user-script.js
@@ -119,7 +119,13 @@ window.parseUserScript = function(content, url, failWhenMissing=false) {
       let locale = data.locale;
       if (locale) {
         if (!locales[locale]) locales[locale] = {};
-        locales[locale][data.keyword] = data.value;
+        if (locales[locale][data.keyword] && data.keyword == 'description') {
+          locales[locale][data.keyword] += ' ' + data.value;
+        } else {
+          locales[locale][data.keyword] = data.value;
+        }
+      } else if (details[data.keyword] && data.keyword == 'description') {
+          details[data.keyword] += ' ' + data.value;
       } else {
         details[data.keyword] = data.value;
       }


### PR DESCRIPTION
I find it hard to describe the quirks that my Greasemonkey scripts are fixing in a single line. Here's a change to concatenate multiple @description meta lines instead of taking the last one.