### PR TITLE
display if overwriting already installed script in install dialog #2877

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -151,6 +151,9 @@
   "install": {
     "message": "Install"
   },
+  "update": {
+    "message": "Update"
+  },
   "install_disabled": {
     "message": "Install in disabled state"
   },

--- a/doc/Messages.md
+++ b/doc/Messages.md
@@ -127,6 +127,21 @@ Passes the user's option values from content to background for persistence.  Req
 
 * `excludes` A string, one `@exclude` pattern per line.
 
+# UserScriptGetByName
+Sent by: `content/install-dialog.js`
+Received by: `bg/user-script-registry.js`
+
+Returns installed user script by namespace and name.
+
+Data:
+
+* `scriptNamespace` The user script's namespace
+* `scriptName` The user script's name
+
+Response:
+
+* The `.details` object of the installed `RunnableUserScript`, or `false` if no user script was found.
+
 # UserScriptGet
 Sent by: `content/edit-user-script.js`
 

--- a/src/bg/user-script-registry.js
+++ b/src/bg/user-script-registry.js
@@ -161,6 +161,25 @@ function onListUserScripts(message, sender, sendResponse) {
 }
 window.onListUserScripts = onListUserScripts;
 
+function onUserScriptGetByName(message, sender, sendResponse) {
+  if (!message.scriptNamespace) {
+    console.warn('UserScriptGetByName handler got no namespace');
+  } else if (!message.scriptName) {
+    console.warn('UserScriptGetByName handler got no name');
+  } else {
+    let userScriptIterator = UserScriptRegistry.scriptsToRunAt(null, true);
+    for (let userScript of userScriptIterator) {
+      if (userScript.namespace === message.scriptNamespace
+          && userScript.name === message.scriptName) {
+        sendResponse(userScript.details);
+        return;
+      }
+    }
+    sendResponse(false);
+  }
+}
+window.onUserScriptGetByName = onUserScriptGetByName;
+
 
 function onUserScriptGet(message, sender, sendResponse) {
   if (!message.uuid) {

--- a/src/content/install-dialog.html
+++ b/src/content/install-dialog.html
@@ -22,7 +22,7 @@
     <tr>
       <td class="icon" rowspan="2"><img rv-src="iconUrl" width="40"></td>
       <td class="name">{name}</td>
-      <td class="version">{version}</td>
+      <td class="version"><span rv-if="installedVersion">{installedVersion} &rarr; </span>{version}</td>
     </tr>
     <tr>
       <td colspan="2">{description}</td>
@@ -101,7 +101,7 @@
   &nbsp;
   <button id="btn-install" class="button-big button-success"
       disabled="disabled"
-      >{'install'|i18n}</button>
+      ><span rv-if="installedVersion | not">{'install'|i18n}</span><span rv-if="installedVersion">{'update'|i18n}</span></button>
 </div>
 
 <script src="/src/i18n.js"></script>

--- a/src/content/install-dialog.js
+++ b/src/content/install-dialog.js
@@ -33,6 +33,24 @@ gDownloader.addProgressListener(() => {
 /****************************** DETAIL DISPLAY *******************************/
 
 gDownloader.scriptDetails.then(scriptDetails => {
+  return new Promise((resolve, reject) => {
+    chrome.runtime.sendMessage({
+        'name': 'UserScriptGetByName',
+        'scriptNamespace' : scriptDetails.namespace,
+        'scriptName' : scriptDetails.name
+      }, (installedScriptDetails) => {
+        if (chrome.runtime.lastError) {
+          console.error(chrome.runtime.lastError);
+          reject(chrome.runtime.lastError);
+        } else {
+          if (installedScriptDetails) {
+            scriptDetails.installedVersion = installedScriptDetails.version;
+          }
+          resolve(scriptDetails);
+        }
+    });
+  });
+}).then(scriptDetails => {
   gDetails = scriptDetails;
 
   document.title = _('NAME_greasemonkey_user_script', gDetails.name);

--- a/test/scripts/update.from.user.js
+++ b/test/scripts/update.from.user.js
@@ -1,0 +1,8 @@
+'use strict';
+// ==UserScript==
+// @name        Update test script 1 of 2
+// @namespace   test-namespace
+// @description Exercises the existing script update logic. Should show the old and the new version in the install dialog.
+// @grant       none
+// @version     1.0
+// ==/UserScript==

--- a/test/scripts/update.to.user.js
+++ b/test/scripts/update.to.user.js
@@ -1,0 +1,8 @@
+'use strict';
+// ==UserScript==
+// @name        Update test script 2 of 2
+// @namespace   test-namespace
+// @description Exercises the existing script update logic. Should show the old and the new version in the install dialog.
+// @grant       none
+// @version     2.0
+// ==/UserScript==


### PR DESCRIPTION
I tried incorporating Sxderp's comments from #2877.

There is a new message UserScriptGetByName in the registry. It accepts namespace and name. There is no fuzzy matching. Only works if both are provided.