### PR TITLE
 Throw meaningful error on forbidden API call 

### DIFF
--- a/src/bg/api-provider-source.js
+++ b/src/bg/api-provider-source.js
@@ -10,7 +10,7 @@ to the global scope (the `this` object).  It ...
 (function() {
 
 function apiProviderSource(userScript) {
-  const grants = userScript.grants;
+  let grants = userScript.grants;
   if (!grants || grants.length == 0
       || (grants.length == 1 && grants[0] == 'none')
   ) {

--- a/src/bg/api-provider-source.js
+++ b/src/bg/api-provider-source.js
@@ -27,7 +27,7 @@ function apiProviderSource(userScript) {
   // This needs to be escaped in case the name contains quotes or backslashes.
   // A name cannot contain line terminators because that would end the name
   // in the original script file.
-  source += 'const _name = "' + escape(userScript.name) + '";\n\n';
+  source += 'const _name = "' + escape(userScript.toString()) + '";\n\n';
   // A private copy of a function that is called when the script calls an API
   // function it has not been granted access to.
   source += 'const _notGranted = ' + throwMissingGrantError.toString() + ';\n\n';

--- a/test/bg/api-provider-source.test.js
+++ b/test/bg/api-provider-source.test.js
@@ -3,11 +3,11 @@ describe('bg/api-provider-source', () => {
   for (let apiName of SUPPORTED_APIS) {
     it('handles ' + apiName, () => {
       let source = apiProviderSource({'grants': [apiName]});
-      assert(!source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(!source.match(new RegExp(apiName + ' = \\(\\) => \\{ _notGranted\\("')));
       assert(source.match(new RegExp(apiName + ' = function GM_')));
       for (let otherApiName of SUPPORTED_APIS) {
         if (otherApiName == apiName) { continue; }
-        assert(source.match(new RegExp(otherApiName + ' = () => { _notGranted("')));
+        assert(source.match(new RegExp(otherApiName + ' = \\(\\) => \\{ _notGranted\\("')));
         assert(!source.match(new RegExp(otherApiName + ' = function GM_')));
       }
     });
@@ -16,7 +16,7 @@ describe('bg/api-provider-source', () => {
   it('handles grant none', () => {
     let source = apiProviderSource({'grants': ['none']});
     for (let apiName of SUPPORTED_APIS) {
-      assert(source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(source.match(new RegExp(apiName + ' = \\(\\) => \\{ _notGranted\\("')));
       assert(!source.match(new RegExp(apiName + ' = function GM_')));
     }
   });
@@ -24,7 +24,7 @@ describe('bg/api-provider-source', () => {
   it('handles no grants', () => {
     let source = apiProviderSource({'grants': []});
     for (let apiName of SUPPORTED_APIS) {
-      assert(source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(source.match(new RegExp(apiName + ' = \\(\\) => \\{ _notGranted\\("')));
       assert(!source.match(new RegExp(apiName + ' = function GM_')));
     }
   });

--- a/test/bg/api-provider-source.test.js
+++ b/test/bg/api-provider-source.test.js
@@ -3,17 +3,29 @@ describe('bg/api-provider-source', () => {
   for (let apiName of SUPPORTED_APIS) {
     it('handles ' + apiName, () => {
       let source = apiProviderSource({'grants': [apiName]});
-      assert(source.match(new RegExp(apiName + ' = ')));
+      assert(!source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(source.match(new RegExp(apiName + ' = function GM_')));
+      for (let otherApiName of SUPPORTED_APIS) {
+        if (otherApiName == apiName) { continue; }
+        assert(source.match(new RegExp(otherApiName + ' = () => { _notGranted("')));
+        assert(!source.match(new RegExp(otherApiName + ' = function GM_')));
+      }
     });
   }
 
   it('handles grant none', () => {
     let source = apiProviderSource({'grants': ['none']});
-    assert(source.match(/No grants/));
+    for (let apiName of SUPPORTED_APIS) {
+      assert(source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(!source.match(new RegExp(apiName + ' = function GM_')));
+    }
   });
 
   it('handles no grants', () => {
     let source = apiProviderSource({'grants': []});
-    assert(source.match(/No grants/));
+    for (let apiName of SUPPORTED_APIS) {
+      assert(source.match(new RegExp(apiName + ' = () => { _notGranted("')));
+      assert(!source.match(new RegExp(apiName + ' = function GM_')));
+    }
   });
 });


### PR DESCRIPTION
(Inspired by the e-mail to the greasemonkey-users mailing list sent by Brent on August 21st, 2018, where he was confused that even the minimalistic example taken from the GM wiki documentation resulted in a `GM.xmlHttpRequest is not a function` error)

Instead of only registering an API function like `GM.listValues` when access was granted, now otherwise register a function that'll throw a meaningful error. This way a script calling `GM.listValues()` w/o declaring `@grant GM.listValues` doesn't produce `TypeError: GM.listValues is not a function` in the error console, but rather `Error: <script name> does not @grant method GM.listValues`.