### PR TITLE
Don't re-enable scripts when saving in editor

### DIFF
--- a/src/content/edit-user-script.js
+++ b/src/content/edit-user-script.js
@@ -188,8 +188,15 @@ function onSave() {
   downloader
       .start()
       .then(() => {
+        return browser.runtime.sendMessage({
+          'name': 'UserScriptGet',
+          'uuid': userScriptUuid,
+        });
+      })
+      .then(userScript => {
+        let details = userScript || gUserScript;
         document.querySelector('#modal progress').removeAttribute('value');
-        return downloader.install('edit');
+        return downloader.install('edit', !details.enabled);
       }).then(onSaveComplete)
       .catch(modalFill);
 }


### PR DESCRIPTION
This change retrieves script details from the background and passes the `enabled` setting to the downloader. If the background sends back undefined, fallback to gUserScript.