### PR TITLE
Set line numbers line-height to match contents

### DIFF
--- a/src/content/edit-user-script.css
+++ b/src/content/edit-user-script.css
@@ -102,6 +102,6 @@ body, #editor {
 body {
   font-size: 14px;
 }
-.CodeMirror pre {
-  line-height: 1.0 !important;
+.CodeMirror-code > div {
+  line-height: 1.15 !important;
 }


### PR DESCRIPTION
Currently the line numbers have one line-height (1.5) and the contents have a
different one (1.0).

I chose 1.15 because it felt too cramped with 1.0, but that can be changed if needed.