### PR TITLE
Expose sections as dialogs for accessibility.

### DIFF
--- a/src/browser/monkey-menu.css
+++ b/src/browser/monkey-menu.css
@@ -41,6 +41,14 @@ section {
   width: 100vw;
 }
 
+/* The active section gets focus so screen readers report the switch to a new
+ * section like a dialog. We don't want the whole section to get a focus
+ * outline visually.
+ */
+section:focus {
+  outline: none;
+}
+
 /* Hide non-main sections by default. */
 section.options,
 section.user-script,

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -9,7 +9,7 @@
 </head>
 <body id="rendering">
 
-<section class="main-menu">
+<section class="main-menu" tabindex="-1" role="dialog">
   <menu>
     <menuitem id="toggle-global-enabled" tabindex="0">
       <i class="icon fa" rv-class-fa-check="enabled"></i>
@@ -87,7 +87,7 @@
 </section>
 
 
-<section class="options">
+<section class="options"  tabindex="-1" role="dialog">
   <header>
     <menuitem tabindex="0" class="go-back"></menuitem>
     {'greasemonkey_options'|i18n}
@@ -113,7 +113,7 @@
 </section>
 
 
-<section class="user-script">
+<section class="user-script"  tabindex="-1" role="dialog">
   <header>
     <menuitem tabindex="0" class="go-back"></menuitem>
     {activeScript.name}
@@ -166,7 +166,7 @@
 </section>
 
 
-<section class="user-script-options">
+<section class="user-script-options"  tabindex="-1" role="dialog">
   <header>
     <menuitem tabindex="0" class="go-back"></menuitem>
     {'options'|i18n} {activeScript.name}

--- a/src/browser/monkey-menu.js
+++ b/src/browser/monkey-menu.js
@@ -141,8 +141,14 @@ function onTransitionEnd() {
   // After a CSS transition has moved a section out of the visible area,
   // force it to be hidden, so that it cannot gain focus.
   for (let section of document.getElementsByTagName('section')) {
-    section.style.visibility = (section.className == document.body.id
+    let isCurrent = section.className == document.body.id;
+    section.style.visibility = (isCurrent
         ? 'visible' : 'hidden');
+    if (isCurrent) {
+      // Make screen readers report the new section like a dialog. Otherwise,
+      // they would report nothing.
+      section.focus();
+    }
   }
 }
 


### PR DESCRIPTION
Previously, screen readers reported nothing when the user switched to a new section. With this change, each section is exposed as a dialog, with the active dialog getting focus. This way, a screen reader will report the content of the new section as if a dialog appeared.

I separated this from #3058 because this one is a bit more controversial, since it messes with focus a tiny bit. Also, I'm totally blind, so I can't confirm whether focusing the sections causes problems visually.