### PR TITLE
Add an optional simple editor which uses a plain textarea.

### DIFF
--- a/_locales/en/messages.json
+++ b/_locales/en/messages.json
@@ -258,5 +258,14 @@
   },
   "xhr_no_url": {
     "message": "GM.xmlHttpRequest: Received no URL."
+  },
+  "editor": {
+    "message": "Editor"
+  },
+  "use_enhanced_editor": {
+    "message": "Use enhanced editor"
+  },
+  "use_enhanced_editor_explain": {
+    "message": "Screen reader users should disable this, as the enhanced code editor is not accessible."
   }
 }

--- a/src/bg/options.js
+++ b/src/bg/options.js
@@ -22,6 +22,11 @@ chrome.storage.local.get('globalExcludes', v => {
   }
 });
 
+let gUseCodeMirror = true;
+chrome.storage.local.get('useCodeMirror', v => {
+  gUseCodeMirror = v['useCodeMirror'];
+  if ('undefined' == typeof gUseCodeMirror) gUseCodeMirror = true;
+});
 
 function getGlobalEnabled() {
   return !!gIsEnabled;
@@ -99,6 +104,7 @@ window.onEnabledToggle = onEnabledToggle;
 function onOptionsLoad(message, sender, sendResponse) {
   let options = {
     'excludes': gGlobalExcludes.join('\n'),
+    'useCodeMirror': gUseCodeMirror,
   };
   sendResponse(options);
 }
@@ -107,9 +113,13 @@ window.onOptionsLoad = onOptionsLoad;
 
 function onOptionsSave(message, sender, sendResponse) {
   chrome.storage.local.set(
-      {'globalExcludes': message.excludes},
+      {
+        'globalExcludes': message.excludes,
+        'useCodeMirror': message.useCodeMirror,
+        },
       logUnhandledError);
   gGlobalExcludes = message.excludes.split('\n');
+  gUseCodeMirror = message.useCodeMirror;
 }
 window.onOptionsSave = onOptionsSave;
 

--- a/src/browser/monkey-menu.html
+++ b/src/browser/monkey-menu.html
@@ -110,6 +110,15 @@
       {'exclude'|i18n} {originGlob}
     </menuitem>
   </p>
+
+  <h2>{'editor'|i18n}</h2>
+  <p>
+    <label>
+      <input type="checkbox" rv-checked="options.useCodeMirror">
+        {'use_enhanced_editor'|i18n}
+    </label>
+  </p>
+  <p class="explain">{'use_enhanced_editor_explain'|i18n}</p>
 </section>
 
 

--- a/src/browser/monkey-menu.js
+++ b/src/browser/monkey-menu.js
@@ -5,6 +5,7 @@ let gTplData = {
   'pendingUninstall': 0,
   'options': {
     'globalExcludesStr': '',
+    'useCodeMirror': true,
   },
   'originGlob': null,
   'userScripts': {
@@ -112,6 +113,7 @@ function onLoad() {
       {'name': 'OptionsLoad'},
       options => {
         gTplData.options.globalExcludesStr = options.excludes;
+        gTplData.options.useCodeMirror = options.useCodeMirror;
         finish();
       });
 
@@ -214,7 +216,7 @@ function activate(el) {
       return;
 
     case 'new-user-script':
-      newUserScript();
+      newUserScript(!gTplData.options.useCodeMirror);
       return;
     case 'toggle-global-enabled':
       browser.runtime.sendMessage({'name': 'EnabledToggle'})
@@ -301,6 +303,7 @@ function navigateAway() {
       chrome.runtime.sendMessage({
         'name': 'OptionsSave',
         'excludes': gTplData.options.globalExcludesStr.trim(),
+        'useCodeMirror': gTplData.options.useCodeMirror,
       }, logUnhandledError);
       break;
     case 'user-script-options':


### PR DESCRIPTION
This is needed by screen reader users, as CodeMirror is unfortunately not accessible. Having a separate editor is not ideal, nor is the missing functionality for screen reader users. Nevertheless, this is far better than a completely inaccessible editor. This at least allows screen reader users to read the content and do basic editing.

A more ideal alternative would be switching to [Monaco](https://microsoft.github.io/monaco-editor/), which is accessible. This would avoid the need for a separate editor and provide advanced functionality for all users. I'm not sure if that is feasible, though.