### PR TITLE
Fix python scripts to work with Python 3

### DIFF
--- a/test/scripts/script-server-slow.py
+++ b/test/scripts/script-server-slow.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """Serve a user script, slowly.
 
 Serve a `.user.js` over HTTP, but very slowly.  The script will stream out
@@ -53,6 +53,6 @@ if __name__ == '__main__':
   if len(argv) == 2:
     port = int(argv[1])
 
-  print 'Starting httpd at http://localhost:%d/ ...' % port
+  print('Starting httpd at http://localhost:%d/ ...' % port)
   httpd = HTTPServer(('', port), S)
   httpd.serve_forever()

--- a/test/scripts/script-server-slow.py
+++ b/test/scripts/script-server-slow.py
@@ -9,7 +9,7 @@ the script finishes.
 
 import time
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
 USER_JS = """// ==UserScript==

--- a/test/scripts/script-server-update.py
+++ b/test/scripts/script-server-update.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python2
+#!/usr/bin/env python3
 """Serve updatable user scripts.
 
 This server will start at version 1, then return a higher version number each
@@ -55,6 +55,6 @@ if __name__ == '__main__':
   if len(argv) == 2:
     port = int(argv[1])
 
-  print 'Starting httpd at http://localhost:%d/ ...' % port
+  print('Starting httpd at http://localhost:%d/ ...' % port)
   httpd = HTTPServer(('', port), S)
   httpd.serve_forever()

--- a/test/scripts/script-server-update.py
+++ b/test/scripts/script-server-update.py
@@ -9,7 +9,7 @@ purposes, the script always has an update available.
 import collections
 import re
 
-from BaseHTTPServer import BaseHTTPRequestHandler, HTTPServer
+from http.server import BaseHTTPRequestHandler, HTTPServer
 
 
 USER_JS = """// ==UserScript==


### PR DESCRIPTION
I do not use Python 2 because it is end-of-life, so I fixed the scripts in `test/scripts` with a name ending with `.py` to make them work with currently supported Python versions, instead of making it only work with Python 2.

Differences:
* The `print` statement no longer exists in Python 3, but a function with the same name provides the same behaviour.
* `BaseHTTPServer` was renamed to `http.server` in Python 3.

After this, when the next version is released, open a security advisory in the `Security` tab to have others upgrade to the latest version as Python 2 will not get anymore updates, even critical security fixes.

**I mean, Python 2 is actually EOL! It was EOL 2 years right after the scripts were added. See https://python.org/doc/sunset-python-2 and https://wiki.python.org/moin/Python2orPython3. I strongly recommend not learning Python 2, learn Python 3 even if you do not want more security.**