### PR TITLE
Fix issue preventing some scripts from auto-updating.

### DIFF
--- a/src/bg/updater.js
+++ b/src/bg/updater.js
@@ -95,20 +95,21 @@ window._pickNextScriptAutoUpdate = async function() {
       return;
     }
 
-    let defaultCheckTime = new Date().getTime() + MIN_UPDATE_IN_MS;
     chrome.storage.local.get(updateNextAtKeys, vs => {
       for (let k of updateNextAtKeys) {
         let uuid = k.replace('updateNextAt.', '');
-        let v = vs[k];
+        // The key will be absent until the script is checked for updates.
+        let v = vs[k] || 0;
 
-        if (!nextTime || !nextUuid || v < nextTime) {
-          nextTime = v || defaultCheckTime;
+        if (!nextUuid || v < nextTime) {
+          nextTime = v;
           nextUuid = uuid;
         }
       }
 
       if (nextUuid) {
-        resolve([nextUuid, nextTime]);
+        let defaultCheckTime = new Date().getTime() + MIN_UPDATE_IN_MS;
+        resolve([nextUuid, nextTime || defaultCheckTime]);
       } else {
         reject('Could not find next script to update.');
       }


### PR DESCRIPTION
GreaseMonkey computes the next scheduled update for each script each time it successfully automatically checks for an update. This information is used to select the next script which automatically check for an update. This change ensures that scripts which do not have this information stored (i.e., scripts which have yet to have a successful automatic update check) will perform their initial automatic update check regardless of the order in which scripts are iterated.

Due to the existing parameters and tuning in GreaseMonkey, this change will result in any update-eligible scripts which have not had their updates checked causing a 3-hour pause of updates. You must ensure that you keep your browser open for at least 3 hours for each script which has not had an automatic update check performed on it before other scripts can resume their normal update schedule.

See #3190 and the discussion of updateNextAt.