### PR TITLE
Add missing error recovery in auto-update logic.

### DIFF
--- a/src/bg/updater.js
+++ b/src/bg/updater.js
@@ -128,8 +128,11 @@ window.scheduleNextScriptAutoUpdate = async function() {
   let delay = nextTime - new Date().getTime();
   delay = Math.max(10000, delay);
   gTimer = setTimeout(async (nextUuid) => {
-    await checkForUpdate(nextUuid);
-    await scheduleNextScriptAutoUpdate();
+    try {
+      await checkForUpdate(nextUuid);
+    } finally {
+      await scheduleNextScriptAutoUpdate();
+    }
   }, delay, nextUuid);
 };
 


### PR DESCRIPTION
It looks like certain error conditions might prevent automatic updates from being rescheduled. This adds recovery.

See #3190 and the discussion of error tolerance.