### PR TITLE
Fix XHR ignoring Cookie header unless it is last

### DIFF
--- a/src/bg/on-user-script-xhr.js
+++ b/src/bg/on-user-script-xhr.js
@@ -112,7 +112,7 @@ function open(xhr, d, port, tabUrl) {
     for (let prop in d.headers) {
       if (Object.prototype.hasOwnProperty.call(d.headers, prop)) {
         let propLower = prop.toLowerCase();
-        hasCookieHeader = (propLower === 'cookie');
+        hasCookieHeader ||= (propLower === 'cookie');
         if (gHeadersToReplace.includes(propLower)) {
           xhr.setRequestHeader(gDummyHeaderPrefix + propLower, d.headers[prop]);
         }


### PR DESCRIPTION
Resolves #3205

The current implementation of XHR ignores `Cookie` header because `hasCookieHeader` is not updated correctly.
This PR fixes the issue.