### PR TITLE
Fix race condition with data load when checking for scripts to run.

### DIFF
--- a/src/bg/execute.js
+++ b/src/bg/execute.js
@@ -6,9 +6,10 @@ content script executions.
 TODO: Make document_start execution time work as intended.
 */
 
-function executeUserscriptOnNavigation(detail) {
+async function executeUserscriptOnNavigation(detail) {
   if (false === getGlobalEnabled()) return;
 
+  await userScriptsReady;
   const userScriptIterator = UserScriptRegistry.scriptsToRunAt(detail.url);
   for (let userScript of userScriptIterator) {
     let options = {


### PR DESCRIPTION
This addresses one race condition discussed in #3117 where scripts would not be run on a tab if the webNavigation.onCommitted event arrives prior to the list of available scripts fully loading.