### PR TITLE
Fix import of scripts with /es in name

### DIFF
--- a/src/content/backup/import.js
+++ b/src/content/backup/import.js
@@ -76,7 +76,7 @@ async function importOneScriptFromZip(zip, file, installedIds, importedIds) {
   if (!file.name.includes('/')) {
     downloader.setScriptUrl('file:///' + file.name);
   } else {
-    let folderName = file.name.substr(0, file.name.lastIndexOf('/'));
+    let folderName = file.name.substr(0, file.name.indexOf('/'));
 
     exportDetails = await zip.file(`${folderName}/.gm.json`)
         .async('text')


### PR DESCRIPTION
This still implies that if you have a script called `a/b/c` and `a/b/d`, only one has valid metadata in the export, but this at least ensures importability of currently-exported archives.

Closes #3210
Closes #3218