### PR TITLE
Fix broken MDN links

### DIFF
--- a/src/bg/options.js
+++ b/src/bg/options.js
@@ -65,7 +65,7 @@ window.onEnabledSet = onEnabledSet;
 
 function setIcon() {
   // Firefox for Android does not have setIcon
-  // https://developer.mozilla.org/en-US/Add-ons/WebExtensions/API/browserAction/setIcon#Browser_compatibility
+  // https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/WebExtensions/API/browserAction/setIcon#Browser_compatibility
   if (!chrome.browserAction.setIcon) {
     return;
   }


### PR DESCRIPTION
Mozilla restructured developer.mozilla.org paths. This PR updates the old Add-ons documentation URLs to the new format.

**Changes:**
- Old URL: `https://developer.mozilla.org/en-US/Add-ons/...`
- New URL: `https://developer.mozilla.org/en-US/docs/Mozilla/Add-ons/...`

---

*Contributed by [theluckystrike](https://github.com/theluckystrike) | [Zovo](https://zovo.one) — Chrome Extension Studio*